### PR TITLE
Fix zmartzone/lua-resty-openidc#45 : Add outgoing proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ http {
              -- You can specify timeouts for connect/send/read as a single number (setting all timeouts) or as a table. Values are in milliseconds
              -- timeout = 1000
              -- timeout = { connect = 500, send = 1000, read = 1000 }
+             
+             -- Optionnal : use outgoing proxy to the OpenID Connect provider endpoints with the proxy_opts table : 
+             -- proxy_opts = {
+             --    http_proxy  = "http://<proxy_host>:<proxy_port>/",
+             --    https_proxy = "http://<proxy_host>:<proxy_port>/"
+             -- }
+
           }
 
           -- call authenticate for OpenID Connect user authentication

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -394,6 +394,7 @@ local function openidc_call_userinfo_endpoint(opts, access_token)
 
   local httpc = http.new()
   openidc_configure_timeouts(httpc, opts.timeout)
+  openidc_configure_proxy(httpc, opts.proxy_opts)
   local res, err = httpc:request_uri(opts.discovery.userinfo_endpoint, {
     headers = headers,
     ssl_verify = (opts.ssl_verify ~= "no")


### PR DESCRIPTION
Hello,

This is a pull request to fix the zmartzone/lua-resty-openidc#45 issue. I'm a lua beginner so my implementation could be naïve. It's work with my use case so I propose my fix to the project : 

* Naïve implementation works with OpendId Connect Authorization
  Code Flow

* Add proxy_opts table to the opts, with two values :
   - http_proxy (in curl format : http://<proxy_host>:<proxy_port>/)
   - https_proxy (in curl format : http://<proxy_host>:<proxy_port>/)

