### PR TITLE
Adding public function to get Discovery Endpoint data

### DIFF
--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -483,6 +483,16 @@ local function openidc_ensure_discovered_data(opts)
   return err
 end
 
+-- query for discovery endpoint data
+function openidc.discover(opts)
+    local err = openidc_ensure_discovered_data (opts)
+    if err then
+      ngx.log(ngx.ERR, "error getting enpoints definition using discovery endpoint")
+    end
+
+    return opts.discovery, err
+end
+
 local function openidc_jwks(url, force, ssl_verify, timeout, proxy_opts)
   ngx.log(ngx.DEBUG, "openidc_jwks: URL is: "..url.. " (force=" .. force .. ")")
 

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -484,10 +484,10 @@ local function openidc_ensure_discovered_data(opts)
 end
 
 -- query for discovery endpoint data
-function openidc.discover(opts)
+function openidc.get_discovery_doc(opts)
     local err = openidc_ensure_discovered_data (opts)
     if err then
-      ngx.log(ngx.ERR, "error getting enpoints definition using discovery endpoint")
+      ngx.log(ngx.ERR, "error getting endpoints definition using discovery endpoint")
     end
 
     return opts.discovery, err


### PR DESCRIPTION
To implement some additional behavior on top of `lua-resty-openidc` library, it is sometimes required to get access to the Discovery Endpoint data.
Instead of re-implementing the overall mechanism to get and cache the discovery data, let's open the corresponding function as public.