### PR TITLE
Adding functions to invalidate the various caches

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+02/08/2018
+- added functions to manually request the invalidation of the caches; see #142
+
 02/06/2018
 - added more logging that may help debugging configuration; see #140; thanks @pamiel
 

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -98,6 +98,23 @@ local function openidc_cache_get(type, key)
   return value
 end
 
+-- invalidate values of server-wide cache
+local function openidc_cache_invalidate(type)
+    local dict = ngx.shared[type]
+    if dict then
+        ngx.log(ngx.DEBUG, "flushing cache for "..type)
+        dict.flush_all(dict)
+        local nbr = dict.flush_expired(dict)
+    end
+end
+
+-- invalidate all server-wide caches
+function openidc.invalidate_caches()
+    openidc_cache_invalidate("discovery")
+    openidc_cache_invalidate("jwks")
+    openidc_cache_invalidate("introspection")
+end
+
 -- validate the contents of and id_token
 local function openidc_validate_id_token(opts, id_token, nonce)
 


### PR DESCRIPTION
A time to live in the server caches for the data retrieved from Discovery and JWKS endpoints is defined (1day). This is good as it enables implementing some specific use cases such as key rotation.

However, it might be required to invalidate the caches immediately, in order an update of the OP to be taken into account immediately, for example.

This PR provide the functions (one internal, and one external) to enable a `lua-resty-openidc` client code to trigger the caches invalidation. Discovery and JWKS, caches are flushed, but also introspection as it is better to re-evaluate tokens as the jwks and discovery data may have changed.