### PR TITLE
Token signature verification error "too long" in case public key starts by 0x80

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+04/11/2018
+- bugfix rare case where OP public key is starting with 0x80 byte, and thus resulting in
+  systematic token signature verification error with message "too long"
+
 02/08/2018
 - added functions to manually request the invalidation of the caches; see #142
 

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -624,7 +624,7 @@ local function encode_sequence(array, of)
 end
 
 local function encode_binary_integer(bytes)
-    if bytes:byte(1) > 128 then
+    if bytes:byte(1) > 127 then
         -- We currenly only use this for unsigned integers,
         -- however since the high bit is set here, it would look
         -- like a negative signed int, so prefix with zeroes


### PR DESCRIPTION
Hello to all of you,

Several issues were raised for “rare” use case of failed verification of Tokens signatures, resulting in a strange error message saying “too long”: here, in `lua-resty-openidc` project (https://github.com/zmartzone/lua-resty-openidc/issues/135), but also in the `lua-restu-jwt` library used by `lua-resty-openidc` when performing the verification of the Token: https://github.com/SkyLothar/lua-resty-jwt/issues/72

My initial thought (as explained in https://github.com/SkyLothar/lua-resty-jwt/issues/72) was that the issue was at very low level, when running the signature verification computation… but indeed it is not: the issue is in the `lua-restu-openidc` processing, when re-building the Public Key from the data obtained from the JWKS endpoint, in case the key is provided using `n` and `e` fields. Let me explain:
-	Once the JWKS endpoint is queried, the process to build the PEM of the public key is initiated by calling `openidc_pem_from_rsa_n_and_e`
-	In this function, the DER/ASN.1 encoding of the key is built thanks to the `encode_sequence_of_integer` function, before the PEM itself is constructed
-	This `encode_sequence_of_integer` function in indeed calling `encode_sequence` giving a pointer to the `encode_binary_integer` function

And issue is in this `encode_binary_integer` function: building the correct Tag / Length / Value of the DER representation of the key requires to consider the key byte array as an unsigned Integer, and thus potentially adding a leading `0x00` byte to the key itself. This SHALL be done as soon as the first byte of the key is above or equal to `0x80`, i.e. 128…
But line https://github.com/zmartzone/lua-resty-openidc/blob/master/lib/resty/openidc.lua#L627 check that the first byte is “greater than 128", while it should check that it is “greater or equal to 128”!

The “rare” occurrence of the problem is due to the fact that it happens only when the RSA public key generated by the OP has a first byte set to `0x80`. For all other values of the first byte, this is not happening.
With the current implementation, in case this byte is `0x80`, the additional leading `0x00` byte is not added to the key, and thus the computation of the length of the key is lowered by one… resulting in a “too long” error message when performing the verification of a token (ok, I might personally have said "too short" because the key is at the end missing 1 byte... but who knows how the error messages have been given in openssl?!).


We experimented this on various keys:
This one is the hexadecimal representation of the DER structure of a valid public key:
```
00000000: 3082 0122 300d 0609 2a86 4886 f70d 0101  0.."0...*.H.....
00000010: 0105 0003 8201 0f00 3082 010a 0282 0101  ........0.......
00000020: 008f 1f80 c306 716a 985a 673c 61b1 354c  ......qj.Zg<a.5L
00000030: 4398 3883 9a13 16de 7918 09e0 dc87 5c29  C.8.....y.....\)
00000040: 2195 1548 ee46 2e93 48ac 2ba9 07ea c80d  !..H.F..H.+.....
00000050: fbca 999d c42a 9083 e684 8831 f89f 92b4  .....*.....1....
00000060: c102 d000 1533 c684 574b ab43 6273 3349  .....3..WK.Cbs3I
00000070: dc02 1ee5 c8a2 c9ef 5fac eaab 1d33 4786  ........_....3G.
00000080: 468b 0b9f e529 28a1 b5f3 f0a5 e83a ece5  F....)(......:..
00000090: 3a58 6d60 2c9c f6d4 54ce 32b2 7f5f 52f9  :Xm`,...T.2.._R.
000000a0: cd8a 6263 7ba3 859c f522 a042 7681 ce09  ..bc{....".Bv...
000000b0: 4adb a40d 6354 2301 d242 c866 70f1 56fd  J...cT#..B.fp.V.
000000c0: 69b5 0bda 66f8 b4e3 4b04 dcf2 90ad 1257  i...f...K......W
000000d0: 633e 952b 9685 5ece 8dda cf4c dc0d 578f  c>.+..^....L..W.
000000e0: 9774 8bd1 476a 9904 e59d 2820 4ef3 82c7  .t..Gj....( N...
000000f0: ed0a 3b3d a5c8 7afa a027 0cd1 25d9 2805  ..;=..z..'..%.(.
00000100: 5d33 df47 4011 ec29 cbd1 2bc3 65f2 c7e3  ]3.G@..)..+.e...
00000110: 5624 f539 9be1 4a24 5942 6e3d 981a 9d14  V$.9..J$YBn=....
00000120: c702 0301 0001                           ......
```
You can see, at byte `0x1C` (end of the second line) the sequence: `0282 0101 008f`
-	`02` is the tag set by https://github.com/zmartzone/lua-resty-openidc/blob/master/lib/resty/openidc.lua#L633
-	`820101` is the size, as computed by `encode_length` function
-	And finally, the key, that starts with byte `8f` is preceded by a `00` byte as `8f` equals 143 in decimal, and 143 is stricty greater than 128 (application of the rule defined here https://github.com/zmartzone/lua-resty-openidc/blob/master/lib/resty/openidc.lua#L607 )

Now, we also had a public key which hexadecimal representation of the DER structure was:
```
00000000: 3082 0122 300d 0609 2a86 4886 f70d 0101  0.."0...*.H.....
00000010: 0105 0003 8201 0f00 3082 0109 0282 0100  ........0.......
00000020: 8007 03d1 2a94 a86d 89f8 b594 ccfc 9861  ....*..m.......a
00000030: e49f ceeb bd36 dec6 6407 3dc6 f04f 5c14  .....6..d.=..O\.
00000040: 44dd cffc 4c16 357f ece5 335a 58e0 8de2  D...L.5...3ZX...
00000050: d8a0 eff8 2733 9f9b a942 9696 51eb ad9a  ....'3...B..Q...
00000060: 7c9f ecbb c9a6 c566 2c66 f25d 9e83 f785  |......f,f.]....
00000070: c883 5fe3 bdc4 14ed e399 efe9 cea3 3366  .._...........3f
00000080: 43bf cb85 3852 3765 f176 55aa f712 e499  C...8R7e.vU.....
00000090: 358b 5400 73af 418f aa2c 08cf bf67 ce0b  5.T.s.A..,...g..
000000a0: 7ca9 0791 12bd bcc8 81e0 3df4 2e13 6c06  |.........=...l.
000000b0: 76b8 06fa 1013 e1c9 b1cc 19a3 c074 c240  v............t.@
000000c0: cf16 3e30 cd6a c724 aa57 e697 ae04 e200  ..>0.j.$.W......
000000d0: 5ee9 dae2 7ff5 6349 c4fa 1f78 3d35 8580  ^.....cI...x=5..
000000e0: a058 7756 d5e0 d769 6ffb df55 2999 3ef9  .XwV...io..U).>.
000000f0: 5cc2 4906 3403 108c 1c23 8cef 1a33 5ff0  \.I.4....#...3_.
00000100: aef0 6068 94e6 7a2a 967a 5283 8faf ef11  ..`h..z*.zR.....
00000110: f1a4 1d30 18b6 f6b8 5318 4006 256c a5c9  ...0....S.@.%l..
00000120: 0203 0100 01                             .....
```
For this one, at byte `0x1C`, the sequence is: `0282 0100 8007`
-	`02` is the tag
-	`820100` is the size computed by `encode_length`. Even if keys in both examples are 2048 bits long, you can see that the size of this second key is smaller by one unit compared to the first example: this is because the key data starts by the `80` byte. The `if` statement of `encode_binary_integer` is not matched because this bytes is exactly equals to 128, and then the `00` byte is NOT added to the payload. So the length has a different value (`0100` instead of `0101`), the key is not preceded by `00`… and the verification of any signature using this key generates a “too long” error (error raised by openssl) !

We have manually updated this public key by adding the missing `00` and re-computed the length… and now the token verification works correctly with this key !


This Pull Request then provides the simple fix for such a complex problem: using `> 127` instead of `> 128` in the `encode_binary_integer` function.
