### PR TITLE
Tighten jwt signature validation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@
 - you can now specify which signing algorithm you expect a bearer token to
   use in order to avoid being tricked into accepting a rogue token signed
   with a symmetric key when expecting an asymmetric cypher.
+- added an option to reject tokens signed by an algorithm not supported by lua-resty-jwt
 
 04/19/2018
 - added support for passing bearer token as cookie

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+- disabled support for "none" alg tokens introduced with 1.5.2 by default.
+  If you want to enable it, you will now have to explicitly set the accept_none_alg
+  option to true.
+
 04/19/2018
 - added support for passing bearer token as cookie
 - added support introspection interval

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,11 @@
 - disabled support for "none" alg tokens introduced with 1.5.2 by default.
   If you want to enable it, you will now have to explicitly set the accept_none_alg
   option to true.
+- id tokens using a signature algorithm not announced by the discovery
+  endpoint are now rejected.
+- you can now specify which signing algorithm you expect a bearer token to
+  use in order to avoid being tricked into accepting a rogue token signed
+  with a symmetric key when expecting an asymmetric cypher.
 
 04/19/2018
 - added support for passing bearer token as cookie

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+04/27/2018
 - disabled support for "none" alg tokens introduced with 1.5.2 by default.
   If you want to enable it, you will now have to explicitly set the accept_none_alg
   option to true.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ http {
              -- if your OpenID Connect Provider doesn't sign its id tokens
              -- (uses the "none" signature algorithm) then set this to true.
 
+             --accept_unsupported_alg = true
+             -- if you want to reject tokens signed using an algorithm
+             -- not supported by lua-resty-jwt set this to false. If
+             -- you leave it unset, the token signature will not be
+             -- verified at all.
+
              --renew_access_token_on_expiry = true
              -- whether this plugin shall try to silently renew the access token once it is expired if a refresh token is available.
              -- if it fails to renew the token, the user will be redirected to the authorization endpoint.
@@ -248,6 +254,12 @@ lAc5Csj0o5Q+oEhPUAVBIF07m4rd0OvAVPOCQ2NJhQSL1oWASbf+fg==
              -- if you want to accept unsigned tokens (using the
              -- "none" signature algorithm) then set this to true.
              --accept_none_alg = false
+
+             -- if you want to reject tokens signed using an algorithm
+             -- not supported by lua-resty-jwt set this to false. If
+             -- you leave it unset, the token signature will not be
+             -- verified at all.
+             --accept_unsupported_alg = true
 
           }
 

--- a/README.md
+++ b/README.md
@@ -238,9 +238,16 @@ lAc5Csj0o5Q+oEhPUAVBIF07m4rd0OvAVPOCQ2NJhQSL1oWASbf+fg==
             -- or both the "n" modulus and "e" exponent entries for RSA signature verification
             -- discovery = "https://accounts.google.com/.well-known/openid-configuration",
 
-             --accept_none_alg = false
+             -- the signature algorithm that you expect has been used;
+             -- can be a single string or a table.
+             -- You should set this for security reasons in order to
+             -- avoid accepting a token claiming to be signed by HMAC
+             -- using a public RSA key.
+             --token_signing_alg_values_expected = { "RS256" }
+
              -- if you want to accept unsigned tokens (using the
              -- "none" signature algorithm) then set this to true.
+             --accept_none_alg = false
 
           }
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ http {
              --token_endpoint_auth_method = ["client_secret_basic"|"client_secret_post"],
              --ssl_verify = "no"
 
+             --accept_none_alg = false
+             -- if your OpenID Connect Provider doesn't sign its id tokens
+             -- (uses the "none" signature algorithm) then set this to true.
+
              --renew_access_token_on_expiry = true
              -- whether this plugin shall try to silently renew the access token once it is expired if a refresh token is available.
              -- if it fails to renew the token, the user will be redirected to the authorization endpoint.
@@ -233,6 +237,11 @@ lAc5Csj0o5Q+oEhPUAVBIF07m4rd0OvAVPOCQ2NJhQSL1oWASbf+fg==
             -- contains "jwks_uri" entry; the jwks endpoint must provide either an "x5c" entry
             -- or both the "n" modulus and "e" exponent entries for RSA signature verification
             -- discovery = "https://accounts.google.com/.well-known/openid-configuration",
+
+             --accept_none_alg = false
+             -- if you want to accept unsigned tokens (using the
+             -- "none" signature algorithm) then set this to true.
+
           }
 
           -- call bearer_jwt_verify for OAuth 2.0 JWT validation

--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ http {
              --accept_unsupported_alg = true
              -- if you want to reject tokens signed using an algorithm
              -- not supported by lua-resty-jwt set this to false. If
-             -- you leave it unset, the token signature will not be
-             -- verified at all.
+             -- you leave it unset or set it to true, the token signature will not be
+             -- verified when an unsupported algorithm is used.
 
              --renew_access_token_on_expiry = true
              -- whether this plugin shall try to silently renew the access token once it is expired if a refresh token is available.

--- a/tests/spec/bearer_token_verification_spec.lua
+++ b/tests/spec/bearer_token_verification_spec.lua
@@ -216,26 +216,26 @@ end)
 
 describe("when using a JWT not signed but using the 'none' alg", function()
   describe("and we are willing to accept the none alg", function()
-  test_support.start_server({
-    verify_opts = {
-      discovery = {
-        jwks_uri = "http://127.0.0.1/jwk",
+    test_support.start_server({
+      verify_opts = {
+        discovery = {
+          jwks_uri = "http://127.0.0.1/jwk",
+        },
+        accept_none_alg = true,
       },
-      accept_none_alg = true,
-    },
-    jwk = test_support.load("/spec/jwks_with_two_keys.json"),
-  })
-  teardown(test_support.stop_server)
-  local jwt = test_support.self_signed_jwt({
-      exp = os.time() + 3600,
-  })
-  local _, status = http.request({
-      url = "http://127.0.0.1/verify_bearer_token",
-      headers = { authorization = "Bearer " .. jwt }
-  })
-  it("the token is valid", function()
-    assert.are.equals(204, status)
-  end)
+      jwk = test_support.load("/spec/jwks_with_two_keys.json"),
+    })
+    teardown(test_support.stop_server)
+    local jwt = test_support.self_signed_jwt({
+        exp = os.time() + 3600,
+    })
+    local _, status = http.request({
+        url = "http://127.0.0.1/verify_bearer_token",
+        headers = { authorization = "Bearer " .. jwt }
+    })
+    it("the token is valid", function()
+      assert.are.equals(204, status)
+    end)
   end)
   describe("and we are not willing to accept the none alg", function()
     test_support.start_server({

--- a/tests/spec/bearer_token_verification_spec.lua
+++ b/tests/spec/bearer_token_verification_spec.lua
@@ -559,3 +559,29 @@ describe("when the token is signed by an RSA key but jwks_uri is empty", functio
     assert.error_log_contains("Invalid token:.*jwks_uri is not present or not a string")
   end)
 end)
+
+describe("when expecting an RSA signature but token uses HMAC", function()
+  test_support.start_server({
+    verify_opts = {
+      secret = test_support.load("/spec/public_rsa_key.pem"),
+      token_signing_alg_values_expected = "RS256"
+    },
+    jwt_verify_secret = test_support.load("/spec/public_rsa_key.pem"),
+    token_header = {
+      alg = "HS256",
+    }
+  })
+  teardown(test_support.stop_server)
+  local jwt = test_support.trim(http.request("http://127.0.0.1/jwt"))
+  local _, status = http.request({
+    url = "http://127.0.0.1/verify_bearer_token",
+    headers = { authorization = "Bearer " .. jwt }
+  })
+  it("the response is invalid", function()
+    assert.are.equals(401, status)
+  end)
+  it("an error has been logged", function()
+    assert.error_log_contains("Invalid token:.*token is signed by unexpected algorithm \"HS256\"")
+  end)
+end)
+

--- a/tests/spec/id_token_validation_spec.lua
+++ b/tests/spec/id_token_validation_spec.lua
@@ -264,3 +264,38 @@ describe("when the id token signature is invalid", function()
   end)
 end)
 
+describe("when the id token signature uses the 'none' alg", function()
+  describe("and we are not willing to accept the none alg", function()
+    test_support.start_server({
+      none_alg_id_token_signature = "true",
+    })
+    teardown(test_support.stop_server)
+    local _, status = test_support.login()
+    it("login has failed", function()
+      assert.are.equals(401, status)
+    end)
+    it("an error message has been logged", function()
+      assert.error_log_contains("id_token 'none' signature verification failed")
+    end)
+    it("authenticate returns an error", function()
+      assert.error_log_contains("authenticate failed: token uses \"none\" alg but accept_none_alg is not enabled")
+    end)
+  end)
+  describe("and we are willing to accept the none alg", function()
+    test_support.start_server({
+      none_alg_id_token_signature = "true",
+      oidc_opts = {
+        accept_none_alg = true,
+      }
+    })
+    teardown(test_support.stop_server)
+    local _, status = test_support.login()
+    it("login succeeds", function()
+      assert.are.equals(302, status)
+    end)
+    it("an message has been logged", function()
+      assert.error_log_contains("accept JWT with alg \"none\" and no signature")
+    end)
+  end)
+end)
+

--- a/tests/spec/id_token_validation_spec.lua
+++ b/tests/spec/id_token_validation_spec.lua
@@ -235,22 +235,22 @@ end)
 
 describe("when the id claims to be signed by an unsupported algorithm", function()
   describe("and accept_unsupported_alg is not set", function()
-  test_support.start_server({
-    fake_id_token_signature = "true",
-    oidc_opts = {
-      discovery = {
-        id_token_signing_alg_values_supported = { "AB256" }
+    test_support.start_server({
+      fake_id_token_signature = "true",
+      oidc_opts = {
+        discovery = {
+          id_token_signing_alg_values_supported = { "AB256" }
+        }
       }
-    }
-  })
-  teardown(test_support.stop_server)
-  local _, status = test_support.login()
-  it("login succeeds", function()
-    assert.are.equals(302, status)
-  end)
-  it("an error is logged", function()
-    assert.error_log_contains("ignored id_token signature as algorithm 'AB256' is not supported")
-  end)
+    })
+    teardown(test_support.stop_server)
+    local _, status = test_support.login()
+    it("login succeeds", function()
+      assert.are.equals(302, status)
+    end)
+    it("an error is logged", function()
+      assert.error_log_contains("ignored id_token signature as algorithm 'AB256' is not supported")
+    end)
   end)
   describe("and accept_unsupported_alg is true", function()
     test_support.start_server({

--- a/tests/spec/test_support.lua
+++ b/tests/spec/test_support.lua
@@ -218,9 +218,9 @@ JWT_VERIFY_SECRET]=]
                   jwt_token = header .. "." .. b64url(id_token) .. "."
                 else
                   jwt_token = create_jwt(id_token, FAKE_ID_TOKEN_SIGNATURE)
-                if BREAK_ID_TOKEN_SIGNATURE then
-                  jwt_token = jwt_token:sub(1, -6) .. "XXXXX"
-                end
+                  if BREAK_ID_TOKEN_SIGNATURE then
+                    jwt_token = jwt_token:sub(1, -6) .. "XXXXX"
+                  end
                 end
                 local token_response = {
                   access_token = access_token,

--- a/tests/spec/test_support.lua
+++ b/tests/spec/test_support.lua
@@ -14,6 +14,7 @@ local DEFAULT_OIDC_CONFIG = {
       issuer = "http://127.0.0.1/",
       jwks_uri = "http://127.0.0.1/jwk",
       userinfo_endpoint = "http://127.0.0.1/user-info",
+      id_token_signing_alg_values_supported = { "RS256", "HS256" },
    },
    client_id = "client_id",
    client_secret = "client_secret",


### PR DESCRIPTION
- disabled support for "none" alg tokens introduced with 1.5.2 by default.
  If you want to enable it, you will now have to explicitly set the accept_none_alg
  option to true.
- id tokens using a signature algorithm not announced by the discovery
  endpoint are now rejected.
- you can now specify which signing algorithm you expect a bearer token to
  use in order to avoid being tricked into accepting a rogue token signed
  with a symmetric key when expecting an asymmetric cypher.
- added an option to reject tokens signed by an algorithm not supported by lua-resty-jwt
