### PR TITLE
Update lua-resty-jwt for OpenSSL 1.1

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -4,4 +4,4 @@ author = Hans Zandbelt (@zandbelt)
 is_original = yes
 license = apache2
 repo_link = https://github.com/zmartzone/lua-resty-openidc
-requires = openresty, pintsized/lua-resty-http >= 0.08, bungle/lua-resty-session >= 2.8, cdbattags/lua-resty-jwt >= 0.2.0, jkeys089/lua-resty-hmac >= 0.2
+requires = openresty, pintsized/lua-resty-http >= 0.08, bungle/lua-resty-session >= 2.8, cdbattags/lua-resty-jwt >= 0.2.0

--- a/dist.ini
+++ b/dist.ini
@@ -4,4 +4,4 @@ author = Hans Zandbelt (@zandbelt)
 is_original = yes
 license = apache2
 repo_link = https://github.com/zmartzone/lua-resty-openidc
-requires = openresty, pintsized/lua-resty-http >= 0.08, bungle/lua-resty-session >= 2.8, SkyLothar/lua-resty-jwt >= 0.1.5, jkeys089/lua-resty-hmac
+requires = openresty, pintsized/lua-resty-http >= 0.08, bungle/lua-resty-session >= 2.8, cdbattags/lua-resty-jwt >= 0.2.0, jkeys089/lua-resty-hmac >= 0.2

--- a/lua-resty-openidc-1.5.4-1.rockspec
+++ b/lua-resty-openidc-1.5.4-1.rockspec
@@ -25,7 +25,7 @@ dependencies = {
     "lua >= 5.1",
     "lua-resty-http >= 0.08",
     "lua-resty-session >= 2.8",
-    "lua-resty-jwt >= 0.1.5",
+    "lua-resty-jwt >= 0.2.0",
     "lua-resty-hmac"
 }
 build = {

--- a/lua-resty-openidc-1.5.4-1.rockspec
+++ b/lua-resty-openidc-1.5.4-1.rockspec
@@ -25,8 +25,7 @@ dependencies = {
     "lua >= 5.1",
     "lua-resty-http >= 0.08",
     "lua-resty-session >= 2.8",
-    "lua-resty-jwt >= 0.2.0",
-    "lua-resty-hmac"
+    "lua-resty-jwt >= 0.2.0"
 }
 build = {
     type = "builtin",


### PR DESCRIPTION
This should add support for OpenSSL 1.1 with the new fork of https://github.com/SkyLothar/lua-resty-jwt at https://github.com/cdbattags/lua-resty-jwt!

Still very confused that you're using two different versions of `lua-resty-hmac` with OPM version and LuaRocks...