### PR TITLE
Support for post_logout_redirect_uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,11 @@ http {
              --redirect_uri_scheme = "https",
              --logout_path = "/logout",
              --redirect_after_logout_uri = "/",
+             -- Where should the user be redirected after logout from the RP. This option overides any end_session_endpoint that the OP may have provided in the discovery response.
              --redirect_after_logout_with_id_token_hint = true,
+             -- Whether the redirection after logout should include the id token as an hint (if available). This option is used only if redirect_after_logout_uri is set.
              --post_logout_redirect_uri = "https://www.zmartzone.eu/logoutSuccessful",
+             -- Where does the RP requests that the OP redirects the user after logout. If this option is set to a relative URI, it will be relative to the OP's logout endpoint, not the RP's.
              --token_endpoint_auth_method = ["client_secret_basic"|"client_secret_post"],
              --ssl_verify = "no"
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ http {
              --logout_path = "/logout",
              --redirect_after_logout_uri = "/",
              --redirect_after_logout_with_id_token_hint = true,
+             --post_logout_redirect_uri = "https://www.zmartzone.eu/logoutSuccessful",
              --token_endpoint_auth_method = ["client_secret_basic"|"client_secret_post"],
              --ssl_verify = "no"
 

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1014,7 +1014,7 @@ local function openidc_logout(opts, session)
        uri = opts.discovery.end_session_endpoint
     end
     local params = {}
-    if (opts.redirect_after_logout_with_id_token_hint or opts.discovery.end_session_endpoint) and session_token then
+    if (opts.redirect_after_logout_with_id_token_hint or not opts.redirect_after_logout_uri) and session_token then
       params["id_token_hint"] = session_token
     end
     if opts.post_logout_redirect_uri then

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -262,6 +262,9 @@ local function openidc_base64_url_decode(input)
 end
 
 local function openidc_combine_uri(uri, params)
+  if params == nil or next(params) == nil then
+    return uri
+  end
   local sep = "?"
   if string.find(uri, "?", 1, true) then
     sep = "&"
@@ -1003,26 +1006,27 @@ local function openidc_logout(opts, session)
     ngx.print(openidc_transparent_pixel)
     ngx.exit(ngx.OK)
     return
-  elseif opts.redirect_after_logout_uri and opts.redirect_after_logout_with_id_token_hint and session_token and opts.post_logout_redirect_uri then
-    return ngx.redirect(openidc_combine_uri(opts.redirect_after_logout_uri, {post_logout_redirect_uri=opts.post_logout_redirect_uri,id_token_hint=session_token}))
-  elseif opts.redirect_after_logout_uri and opts.redirect_after_logout_with_id_token_hint and session_token then
-    return ngx.redirect(openidc_combine_uri(opts.redirect_after_logout_uri, {id_token_hint=session_token}))
-  elseif opts.redirect_after_logout_uri and opts.post_logout_redirect_uri then
-    return ngx.redirect(openidc_combine_uri(opts.redirect_after_logout_uri, {post_logout_redirect_uri=opts.post_logout_redirect_uri}))
-  elseif opts.redirect_after_logout_uri then
-    return ngx.redirect(opts.redirect_after_logout_uri)
-  elseif opts.discovery.end_session_endpoint and opts.post_logout_redirect_uri and session_token then
-    return ngx.redirect(openidc_combine_uri(opts.discovery.end_session_endpoint, {post_logout_redirect_uri=opts.post_logout_redirect_uri,id_token_hint=session_token}))
-  elseif opts.discovery.end_session_endpoint and session_token then
-    return ngx.redirect(openidc_combine_uri(opts.discovery.end_session_endpoint, {id_token_hint=session_token}))
-  elseif opts.discovery.end_session_endpoint and opts.post_logout_redirect_uri then
-    return ngx.redirect(openidc_combine_uri(opts.discovery.end_session_endpoint, {post_logout_redirect_uri=opts.post_logout_redirect_uri}))
-  elseif opts.discovery.end_session_endpoint then
-    return ngx.redirect(opts.discovery.end_session_endpoint)
-  elseif opts.discovery.ping_end_session_endpoint and opts.post_logout_redirect_uri then
-    return ngx.redirect(openidc_combine_uri(opts.discovery.ping_end_session_endpoint, {TargetResource=opts.post_logout_redirect_uri}))
+  elseif opts.redirect_after_logout_uri or opts.discovery.end_session_endpoint then
+    local uri
+    if opts.redirect_after_logout_uri then
+       uri = opts.redirect_after_logout_uri
+    else
+       uri = opts.discovery.end_session_endpoint
+    end
+    local params = {}
+    if opts.redirect_after_logout_with_id_token_hint and session_token then
+      params["id_token_hint"] = session_token
+    end
+    if opts.post_logout_redirect_uri then
+      params["post_logout_redirect_uri"] = opts.post_logout_redirect_uri
+    end
+    return ngx.redirect(openidc_combine_uri(uri, params))
   elseif opts.discovery.ping_end_session_endpoint then
-    return ngx.redirect(opts.discovery.ping_end_session_endpoint)
+    local params = {}
+    if opts.post_logout_redirect_uri then
+      params["TargetResource"] = opts.post_logout_redirect_uri
+    end
+    return ngx.redirect(openidc_combine_uri(opts.discovery.ping_end_session_endpoint, params))
   end
 
   ngx.header.content_type = "text/html"

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1003,14 +1003,24 @@ local function openidc_logout(opts, session)
     ngx.print(openidc_transparent_pixel)
     ngx.exit(ngx.OK)
     return
+  elseif opts.redirect_after_logout_uri and opts.redirect_after_logout_with_id_token_hint and session_token and opts.post_logout_redirect_uri then
+    return ngx.redirect(openidc_combine_uri(opts.redirect_after_logout_uri, {post_logout_redirect_uri=opts.post_logout_redirect_uri,id_token_hint=session_token}))
   elseif opts.redirect_after_logout_uri and opts.redirect_after_logout_with_id_token_hint and session_token then
     return ngx.redirect(openidc_combine_uri(opts.redirect_after_logout_uri, {id_token_hint=session_token}))
+  elseif opts.redirect_after_logout_uri and opts.post_logout_redirect_uri then
+    return ngx.redirect(openidc_combine_uri(opts.redirect_after_logout_uri, {post_logout_redirect_uri=opts.post_logout_redirect_uri}))
   elseif opts.redirect_after_logout_uri then
     return ngx.redirect(opts.redirect_after_logout_uri)
+  elseif opts.discovery.end_session_endpoint and opts.post_logout_redirect_uri and session_token then
+    return ngx.redirect(openidc_combine_uri(opts.discovery.end_session_endpoint, {post_logout_redirect_uri=opts.post_logout_redirect_uri,id_token_hint=session_token}))
   elseif opts.discovery.end_session_endpoint and session_token then
     return ngx.redirect(openidc_combine_uri(opts.discovery.end_session_endpoint, {id_token_hint=session_token}))
+  elseif opts.discovery.end_session_endpoint and opts.post_logout_redirect_uri then
+    return ngx.redirect(openidc_combine_uri(opts.discovery.end_session_endpoint, {post_logout_redirect_uri=opts.post_logout_redirect_uri}))
   elseif opts.discovery.end_session_endpoint then
     return ngx.redirect(opts.discovery.end_session_endpoint)
+  elseif opts.discovery.ping_end_session_endpoint and opts.post_logout_redirect_uri then
+    return ngx.redirect(openidc_combine_uri(opts.discovery.ping_end_session_endpoint, {TargetResource=opts.post_logout_redirect_uri}))
   elseif opts.discovery.ping_end_session_endpoint then
     return ngx.redirect(opts.discovery.ping_end_session_endpoint)
   end

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1014,7 +1014,7 @@ local function openidc_logout(opts, session)
        uri = opts.discovery.end_session_endpoint
     end
     local params = {}
-    if opts.redirect_after_logout_with_id_token_hint and session_token then
+    if (opts.redirect_after_logout_with_id_token_hint or opts.discovery.end_session_endpoint) and session_token then
       params["id_token_hint"] = session_token
     end
     if opts.post_logout_redirect_uri then


### PR DESCRIPTION
I need the ability control the final page where the End-User’s User
Agent gets redirected to by the OP during an RP-Initiated Logout.

As per OpenID Connect Session Management 1.0 draft spec, the optional
URL parameter post_logout_redirect_uri is intended for this:

https://openid.net/specs/openid-connect-session-1_0.html#RPLogout

So I’ve added support for this parameter. Note that the current version
of Ping Federate uses a different URL parameter (TargetResource).