### PR TITLE
bypass introspection cache on demand.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,4 +28,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Thomas Leplus <https://github.com/thomasleplus>
 	Donghang Lin <https://github.com/dhlin>
 	Arcadiy Ivanov <https://github.com/arcivanov>
-        Dmitriy Blok <https://github.com/dmitriyblok>
+	Dmitriy Blok <https://github.com/dmitriyblok>

--- a/AUTHORS
+++ b/AUTHORS
@@ -28,3 +28,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Thomas Leplus <https://github.com/thomasleplus>
 	Donghang Lin <https://github.com/dhlin>
 	Arcadiy Ivanov <https://github.com/arcivanov>
+        Dmitriy Blok <https://github.com/dmitriyblok>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 09/04/2018
 - bypass introspection cache on demand. 
   Sometimes it is necessary to force introspection call for token. If you want to force
-  introspection call, you need to set set the ignore_cache option to "yes".
+  introspection call, you need to set set the introspection_cache_ignore option to "yes".
 
 07/18/2018
 - extract log function and log level constant to the module level to allow customization

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,5 @@
-09/04/2018
-- bypass introspection cache on demand. 
-  Sometimes it is necessary to force introspection call for token. If you want to force
-  introspection call, you need to set set the introspection_cache_ignore option to "yes".
+09/06/2018
+- bypass introspection cache on demand with introspection_cache_ignore; thanks @dmitriyblok
 
 07/18/2018
 - extract log function and log level constant to the module level to allow customization

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+09/04/2018
+- bypass introspection cache on demand. 
+  Sometimes it is necessary to force introspection call for token. If you want to force
+  introspection call, you need to set set the ignore_cache option to "yes".
+
 07/18/2018
 - extract log function and log level constant to the module level to allow customization
 

--- a/README.md
+++ b/README.md
@@ -440,6 +440,10 @@ http {
              -- Defaults to "exp" - Controls the TTL of the introspection cache
              -- https://tools.ietf.org/html/rfc7662#section-2.2
              -- introspection_expiry_claim = "exp"
+             
+             -- It may be necessary to force an introspection call for an access_token and ignore the existing cached
+             -- introspection results. If so you need to set set the introspection_cache_ignore option to true.
+             -- introspection_cache_ignore = true
           }
 
           -- call introspect for OAuth 2.0 Bearer Access Token validation

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1390,9 +1390,9 @@ function openidc.introspect(opts)
   -- see if we've previously cached the introspection result for this access token
   local json
   local v
-  local ignore_cache = opts.ignore_cache or "no"
+  local introspection_cache_ignore = opts.introspection_cache_ignore or "no"
 
-  if ignore_cache == "no" then
+  if introspection_cache_ignore == "no" then
     v = openidc_cache_get("introspection", access_token)
   end
 
@@ -1423,7 +1423,7 @@ function openidc.introspect(opts)
     -- cache the results
     if json then
       if json.active then
-        if ignore_cache == "no" then
+        if introspection_cache_ignore == "no" then
           local expiry_claim = opts.introspection_expiry_claim or "exp"
           local introspection_interval = opts.introspection_interval or 0
           if json[expiry_claim] then

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1389,6 +1389,7 @@ function openidc.introspect(opts)
 
   -- see if we've previously cached the introspection result for this access token
   local json
+  local v
   local ignore_cache = opts.ignore_cache or "no"
 
   if ignore_cache == "no" then

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1390,9 +1390,9 @@ function openidc.introspect(opts)
   -- see if we've previously cached the introspection result for this access token
   local json
   local v
-  local introspection_cache_ignore = opts.introspection_cache_ignore or "no"
+  local introspection_cache_ignore = opts.introspection_cache_ignore or false
 
-  if introspection_cache_ignore == "no" then
+  if not introspection_cache_ignore then
     v = openidc_cache_get("introspection", access_token)
   end
 
@@ -1437,7 +1437,7 @@ function openidc.introspect(opts)
   local expiry_claim = opts.introspection_expiry_claim or "exp"
   local introspection_interval = opts.introspection_interval or 0
 
-  if introspection_cache_ignore == "no" and json[expiry_claim] then
+  if not introspection_cache_ignore and json[expiry_claim] then
     local ttl = json[expiry_claim]
     if expiry_claim == "exp" then --https://tools.ietf.org/html/rfc7662#section-2.2
       ttl = ttl - ngx.time()

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1396,60 +1396,64 @@ function openidc.introspect(opts)
     v = openidc_cache_get("introspection", access_token)
   end
 
-  if not v then
+  if v then
+    json = cjson.decode(v)
+    return json, err
+  end
 
-    -- assemble the parameters to the introspection (token) endpoint
-    local token_param_name = opts.introspection_token_param_name and opts.introspection_token_param_name or "token"
+  -- assemble the parameters to the introspection (token) endpoint
+  local token_param_name = opts.introspection_token_param_name and opts.introspection_token_param_name or "token"
 
-    local body = {}
+  local body = {}
 
-    body[token_param_name] = access_token
+  body[token_param_name] = access_token
 
-    if opts.client_id then
-      body.client_id = opts.client_id
+  if opts.client_id then
+    body.client_id = opts.client_id
+  end
+  if opts.client_secret then
+    body.client_secret = opts.client_secret
+  end
+
+  -- merge any provided extra parameters
+  if opts.introspection_params then
+    for key, val in pairs(opts.introspection_params) do body[key] = val end
+  end
+
+  -- call the introspection endpoint
+  json, err = openidc_call_token_endpoint(opts, opts.introspection_endpoint, body, opts.introspection_endpoint_auth_method, "introspection")
+
+
+  if not json then
+    return json, err
+  end
+
+  if not json.active then
+    err = "invalid token"
+    return json, err
+  end
+
+  -- cache the results
+  local expiry_claim = opts.introspection_expiry_claim or "exp"
+  local introspection_interval = opts.introspection_interval or 0
+
+  if introspection_cache_ignore == "no" and json[expiry_claim] then
+    local ttl = json[expiry_claim]
+    if expiry_claim == "exp" then --https://tools.ietf.org/html/rfc7662#section-2.2
+      ttl = ttl - ngx.time()
     end
-    if opts.client_secret then
-      body.client_secret = opts.client_secret
-    end
-
-    -- merge any provided extra parameters
-    if opts.introspection_params then
-      for key, val in pairs(opts.introspection_params) do body[key] = val end
-    end
-
-    -- call the introspection endpoint
-    json, err = openidc_call_token_endpoint(opts, opts.introspection_endpoint, body, opts.introspection_endpoint_auth_method, "introspection")
-
-    -- cache the results
-    if json then
-      if json.active then
-        if introspection_cache_ignore == "no" then
-          local expiry_claim = opts.introspection_expiry_claim or "exp"
-          local introspection_interval = opts.introspection_interval or 0
-          if json[expiry_claim] then
-            local ttl = json[expiry_claim]
-            if expiry_claim == "exp" then --https://tools.ietf.org/html/rfc7662#section-2.2
-              ttl = ttl - ngx.time()
-            end
-            if introspection_interval > 0 then
-              if ttl > introspection_interval then
-                ttl = introspection_interval
-              end
-            end
-            log(DEBUG, "cache token ttl: " .. ttl)
-            openidc_cache_set("introspection", access_token, cjson.encode(json), ttl)
-          end
-        end
-      else
-        err = "invalid token"
+    if introspection_interval > 0 then
+      if ttl > introspection_interval then
+        ttl = introspection_interval
       end
     end
+    log(DEBUG, "cache token ttl: " .. ttl)
+    openidc_cache_set("introspection", access_token, cjson.encode(json), ttl)
 
-  else
-    json = cjson.decode(v)
   end
 
   return json, err
+
 end
 
 -- main routine for OAuth 2.0 JWT token validation


### PR DESCRIPTION
Added ability to bypass introspection cache. I found that I needed in certain situations for calls to always introspect the token regardless of whether it is cached or not and not affect the state of cache. 