### PR TITLE
add an option to suppress the nonce parameter

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+09/15/2019
+- add an option to disable nonce parameter for broken OpenID Connect providers
+
 09/06/2018
 - bypass introspection cache on demand with introspection_cache_ignore; thanks @dmitriyblok
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,13 @@ http {
              -- timeout = 1000
              -- timeout = { connect = 500, send = 1000, read = 1000 }
 
+             --use_nonce = false
+             -- By default the authorization request includes the
+             -- nonce paramter. You can use this option to disable it
+             -- which may be necessary when talking to a broken OpenID
+             -- Connect provider that ignores the paramter as the
+             -- id_token will be rejected otherwise.
+
              -- Optional : use outgoing proxy to the OpenID Connect provider endpoints with the proxy_opts table : 
              -- this requires lua-resty-http >= 0.12
              -- proxy_opts = {

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -286,7 +286,8 @@ local function openidc_authorize(opts, session, target_url, prompt)
 
   -- generate state and nonce
   local state = resty_string.to_hex(resty_random.bytes(16))
-  local nonce = resty_string.to_hex(resty_random.bytes(16))
+  local nonce = (opts.use_nonce == nil or opts.use_nonce)
+    and resty_string.to_hex(resty_random.bytes(16))
 
   -- assemble the parameters to the authentication request
   local params = {
@@ -295,8 +296,11 @@ local function openidc_authorize(opts, session, target_url, prompt)
     scope = opts.scope and opts.scope or "openid email profile",
     redirect_uri = openidc_get_redirect_uri(opts),
     state = state,
-    nonce = nonce,
   }
+
+  if nonce then
+    params.nonce = nonce
+  end
 
   if prompt then
     params.prompt = prompt

--- a/tests/spec/redirect_to_op_spec.lua
+++ b/tests/spec/redirect_to_op_spec.lua
@@ -410,3 +410,26 @@ describe("when accessing the protected resource without token and multiple forwa
   end)
 end)
 
+describe("when explicitly setting the use_nonce option to true", function()
+  test_support.start_server({oidc_opts = {use_nonce = true}})
+  teardown(test_support.stop_server)
+  local _, status, headers = http.request({
+    url = "http://127.0.0.1/default/t",
+    redirect = false
+  })
+  it("uses a nonce parameter", function()
+    assert.truthy(string.match(headers["location"], ".*nonce=.*"))
+  end)
+end)
+
+describe("when setting the use_nonce option to false", function()
+  test_support.start_server({oidc_opts = {use_nonce = false}})
+  teardown(test_support.stop_server)
+  local _, status, headers = http.request({
+    url = "http://127.0.0.1/default/t",
+    redirect = false
+  })
+  it("doesn't use a nonce parameter", function()
+    assert.falsy(string.match(headers["location"], ".*nonce=.*"))
+  end)
+end)


### PR DESCRIPTION
needed to deal with broken OpenID Connect providers, closes #193
