### PR TITLE
HTTP request decorator

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+09/17/2019
+- added an optional "request decorator" option that can be used to augment
+  the HTTP requests when lua-resty-openidc talks to the discovery,
+  token or jwks endpoints.
+
 09/15/2019
 - add an option to disable nonce parameter for broken OpenID Connect providers
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,17 @@ http {
              --    https_proxy = "http://<proxy_host>:<proxy_port>/"
              -- }
 
+             -- Optional : add decorator for HTTP request that is
+             -- applied when lua-resty-openidc talks to the OpenID Connect
+             -- provider directly. Can be used to provide extra HTPP headers
+             -- or add other similar behavior.
+             -- http_request_decorator = function(req)
+             --   local h = req.headers or {}
+             --   h[EXTRA_HEADER] = 'my extra header'
+             --   req.headers = h
+             --   return req
+             -- end,
+
           }
 
           -- call authenticate for OpenID Connect user authentication

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -279,6 +279,10 @@ local function openidc_combine_uri(uri, params)
   return uri .. sep .. ngx.encode_args(params)
 end
 
+local function decorate_request(http_request_decorator, req)
+  return http_request_decorator and http_request_decorator(req) or req
+end
+
 -- send the browser of to the OP's authorization endpoint
 local function openidc_authorize(opts, session, target_url, prompt)
   local resty_random = require("resty.random")
@@ -408,12 +412,12 @@ local function openidc_call_token_endpoint(opts, endpoint, body, auth, endpoint_
   local httpc = http.new()
   openidc_configure_timeouts(httpc, opts.timeout)
   openidc_configure_proxy(httpc, opts.proxy_opts)
-  local res, err = httpc:request_uri(endpoint, {
+  local res, err = httpc:request_uri(endpoint, decorate_request(opts.http_request_decorator, {
     method = "POST",
     body = ngx.encode_args(body),
     headers = headers,
     ssl_verify = (opts.ssl_verify ~= "no")
-  })
+  }))
   if not res then
     err = "accessing " .. ep_name .. " endpoint (" .. endpoint .. ") failed: " .. err
     log(ERROR, err)
@@ -441,10 +445,11 @@ local function openidc_call_userinfo_endpoint(opts, access_token)
   local httpc = http.new()
   openidc_configure_timeouts(httpc, opts.timeout)
   openidc_configure_proxy(httpc, opts.proxy_opts)
-  local res, err = httpc:request_uri(opts.discovery.userinfo_endpoint, {
+  local res, err = httpc:request_uri(opts.discovery.userinfo_endpoint,
+                                     decorate_request(opts.http_request_decorator, {
     headers = headers,
     ssl_verify = (opts.ssl_verify ~= "no")
-  })
+  }))
   if not res then
     err = "accessing (" .. opts.discovery.userinfo_endpoint .. ") failed: " .. err
     return nil, err
@@ -477,7 +482,7 @@ local function openidc_load_jwt_none_alg(enc_hdr, enc_payload)
 end
 
 -- get the Discovery metadata from the specified URL
-local function openidc_discover(url, ssl_verify, timeout, exptime, proxy_opts)
+local function openidc_discover(url, ssl_verify, timeout, exptime, proxy_opts, http_request_decorator)
   log(DEBUG, "openidc_discover: URL is: " .. url)
 
   local json, err
@@ -489,9 +494,9 @@ local function openidc_discover(url, ssl_verify, timeout, exptime, proxy_opts)
     local httpc = http.new()
     openidc_configure_timeouts(httpc, timeout)
     openidc_configure_proxy(httpc, proxy_opts)
-    local res, error = httpc:request_uri(url, {
+    local res, error = httpc:request_uri(url, decorate_request(http_request_decorator, {
       ssl_verify = (ssl_verify ~= "no")
-    })
+    }))
     if not res then
       err = "accessing discovery url (" .. url .. ") failed: " .. error
       log(ERROR, err)
@@ -523,7 +528,8 @@ end
 local function openidc_ensure_discovered_data(opts)
   local err
   if type(opts.discovery) == "string" then
-    opts.discovery, err = openidc_discover(opts.discovery, opts.ssl_verify, opts.timeout, opts.jwk_expires_in, opts.proxy_opts)
+    opts.discovery, err = openidc_discover(opts.discovery, opts.ssl_verify, opts.timeout, opts.jwk_expires_in, opts.proxy_opts,
+                                           opts.http_request_decorator)
   end
   return err
 end
@@ -598,8 +604,8 @@ function openidc.get_discovery_doc(opts)
   return opts.discovery, err
 end
 
-local function openidc_jwks(url, force, ssl_verify, timeout, exptime, proxy_opts)
-  log(DEBUG, "openidc_jwks: URL is: " .. url .. " (force=" .. force .. ")")
+local function openidc_jwks(url, force, ssl_verify, timeout, exptime, proxy_opts, http_request_decorator)
+  log(DEBUG, "openidc_jwks: URL is: "..url.. " (force=" .. force .. ") (decorator=" .. (http_request_decorator and type(http_request_decorator) or "nil"))
 
   local json, err, v
 
@@ -614,9 +620,9 @@ local function openidc_jwks(url, force, ssl_verify, timeout, exptime, proxy_opts
     local httpc = http.new()
     openidc_configure_timeouts(httpc, timeout)
     openidc_configure_proxy(httpc, proxy_opts)
-    local res, error = httpc:request_uri(url, {
+    local res, error = httpc:request_uri(url, decorate_request(http_request_decorator, {
       ssl_verify = (ssl_verify ~= "no")
-    })
+    }))
     if not res then
       err = "accessing jwks url (" .. url .. ") failed: " .. error
       log(ERROR, err)
@@ -773,7 +779,8 @@ local function openidc_pem_from_jwk(opts, kid)
   local jwk, jwks
 
   for force = 0, 1 do
-    jwks, err = openidc_jwks(opts.discovery.jwks_uri, force, opts.ssl_verify, opts.timeout, opts.jwk_expires_in, opts.proxy_opts)
+    jwks, err = openidc_jwks(opts.discovery.jwks_uri, force, opts.ssl_verify, opts.timeout, opts.jwk_expires_in, opts.proxy_opts,
+                             opts.http_request_decorator)
     if err then
       return nil, err
     end

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -605,7 +605,7 @@ function openidc.get_discovery_doc(opts)
 end
 
 local function openidc_jwks(url, force, ssl_verify, timeout, exptime, proxy_opts, http_request_decorator)
-  log(DEBUG, "openidc_jwks: URL is: "..url.. " (force=" .. force .. ") (decorator=" .. (http_request_decorator and type(http_request_decorator) or "nil"))
+  log(DEBUG, "openidc_jwks: URL is: " .. url .. " (force=" .. force .. ") (decorator=" .. (http_request_decorator and type(http_request_decorator) or "nil"))
 
   local json, err, v
 

--- a/tests/spec/bearer_token_verification_spec.lua
+++ b/tests/spec/bearer_token_verification_spec.lua
@@ -624,3 +624,22 @@ describe("when using a 4k RSA key from a JWK that doesn't contain the x5c claim"
   base_checks()
 end)
 
+describe("when a request_decorator has been specified when calling the jwks endpoint", function()
+  test_support.start_server({
+    verify_opts = {
+      discovery = {
+        jwks_uri = "http://127.0.0.1/jwk",
+      },
+      decorate = true
+    },
+  })
+  teardown(test_support.stop_server)
+  local jwt = test_support.trim(http.request("http://127.0.0.1/jwt"))
+  http.request({
+    url = "http://127.0.0.1/verify_bearer_token",
+    headers = { authorization = "Bearer " .. jwt }
+  })
+  it("the request contains the additional parameter", function()
+    assert.error_log_contains('jwk uri_args:.*"foo"%s*:%s*"bar"')
+  end)
+end)

--- a/tests/spec/introspection_spec.lua
+++ b/tests/spec/introspection_spec.lua
@@ -508,3 +508,21 @@ describe("when introspection endpoint doesn't return proper JSON", function()
     assert.error_log_contains("Introspection error: JSON decoding failed")
   end)
 end)
+
+describe("when a request_decorator has been specified when calling the token endpoint", function()
+  test_support.start_server({
+    introspection_opts = {
+      decorate = true
+    }
+  })
+  teardown(test_support.stop_server)
+  local jwt = test_support.trim(http.request("http://127.0.0.1/jwt"))
+  http.request({
+    url = "http://127.0.0.1/introspect",
+    headers = { authorization = "Bearer " .. jwt }
+  })
+  it("the request contains the additional parameter", function()
+    assert_introspection_endpoint_call_contains("foo=bar")
+  end)
+end)
+

--- a/tests/spec/redirect_to_op_spec.lua
+++ b/tests/spec/redirect_to_op_spec.lua
@@ -433,3 +433,20 @@ describe("when setting the use_nonce option to false", function()
     assert.falsy(string.match(headers["location"], ".*nonce=.*"))
   end)
 end)
+
+describe("when a request_decorator has been specified when calling the discovery endpoint", function()
+  test_support.start_server({
+    oidc_opts = {
+      discovery = "http://127.0.0.1/discovery",
+      decorate = "query"
+    },
+  })
+  teardown(test_support.stop_server)
+  http.request({
+    url = "http://127.0.0.1/default/t",
+    redirect = false
+  })
+  it("the request contains the additional parameter", function()
+    assert.error_log_contains('discovery uri_args:.*"foo"%s*:%s*"bar"')
+  end)
+end)

--- a/tests/spec/token_request_spec.lua
+++ b/tests/spec/token_request_spec.lua
@@ -200,3 +200,16 @@ describe("if token endpoint doesn't return proper JSON", function()
     assert.error_log_contains("authenticate failed: JSON decoding failed")
   end)
 end)
+
+describe("when a request_decorator has been specified when calling the token endpoint", function()
+  test_support.start_server({
+    oidc_opts = {
+      decorate = "body"
+    }
+  })
+  teardown(test_support.stop_server)
+  test_support.login()
+  it("the request contains the additional parameter", function()
+    assert_token_endpoint_call_contains("foo=bar")
+  end)
+end)


### PR DESCRIPTION
adds an optional decorator function that can be used to tweak the HTTP request when lua-resty-openidc talks to the OP.

One use case is passing on correlation tokens or other tracing information.