### PR TITLE
Revoke refresh_token and access_token on logout

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,3 +29,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Donghang Lin <https://github.com/dhlin>
 	Arcadiy Ivanov <https://github.com/arcivanov>
 	Dmitriy Blok <https://github.com/dmitriyblok>
+	Oleander Reis <https://github.com/oleeander>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+10/18/2018
+- add token revocation support on logout (opts.revoke_tokens_on_logout)
+
 10/16/2018
 - lua-resty-openidc now creates a new session whenever the token(s)
   are refreshed, trying to soften the impact when multiple requests

--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ http {
              -- Connect provider that ignores the paramter as the
              -- id_token will be rejected otherwise.
 
+             --revoke_tokens_on_logout = false
+             -- When revoke_tokens_on_logout is set to true a logout notifies the authorization server that previously obtained refresh and access tokens are no longer needed. This requires that revocation_endpoint is discoverable.
+             -- If there is no revocation endpoint supplied or if there are errors on revocation the user will not be notified and the logout process continues normally.
+
              -- Optional : use outgoing proxy to the OpenID Connect provider endpoints with the proxy_opts table : 
              -- this requires lua-resty-http >= 0.12
              -- proxy_opts = {

--- a/tests/spec/test_support.lua
+++ b/tests/spec/test_support.lua
@@ -370,6 +370,23 @@ JWT_SIGN_SECRET]=]
                 end
             }
         }
+
+        location /revocation {
+            content_by_lua_block {
+                ngx.req.read_body()
+                ngx.log(ngx.ERR, "Received revocation request: " .. ngx.req.get_body_data())
+                local auth = ngx.req.get_headers()["Authorization"]
+                ngx.log(ngx.ERR, "revocation authorization header: " .. (auth and auth or ""))
+                local cookie = ngx.req.get_headers()["Cookie"]
+                if not cookie then
+                  ngx.log(ngx.ERR, "no cookie in introspection call")
+                end
+                ngx.header.content_type = 'application/json;charset=UTF-8'
+                delay(REVOCATION_DELAY_RESPONSE)
+                ngx.status = 200
+                ngx.say('INVALID JSON.')
+            }
+        }
     }
 }
 ]]
@@ -450,6 +467,7 @@ local function write_config(out, custom_config)
     :gsub("DISCOVERY_DELAY_RESPONSE", ((custom_config["delay_response"] or {}).discovery or DEFAULT_DELAY_RESPONSE))
     :gsub("USERINFO_DELAY_RESPONSE", ((custom_config["delay_response"] or {}).userinfo or DEFAULT_DELAY_RESPONSE))
     :gsub("INTROSPECTION_DELAY_RESPONSE", ((custom_config["delay_response"] or {}).introspection or DEFAULT_DELAY_RESPONSE))
+    :gsub("REVOCATION_DELAY_RESPONSE", ((custom_config["delay_response"] or {}).revocation or DEFAULT_DELAY_RESPONSE))
     :gsub("JWK", custom_config["jwk"] or DEFAULT_JWK)
     :gsub("USERINFO", serpent.block(userinfo, {comment = false }))
     :gsub("FAKE_ACCESS_TOKEN_SIGNATURE", custom_config["fake_access_token_signature"] or DEFAULT_FAKE_ACCESS_TOKEN_SIGNATURE)


### PR DESCRIPTION
Notify the authorization server that previously obtained
refresh and access tokens are no longer needed after logout.

Currently this happens in a completely opportunistic way.
If there is no revocation endpoint supplied, a debug message
will be logged and the logout process continues.

If there is a revocation endpoint supplied but the
authorization server does not respond with
HTTP status code 200, an error message will be logged but
the logout process still continues as if there was no error.