### PR TITLE
Added openidc_ensure_discovered_data to openidc_authorization_response

### DIFF
--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -995,7 +995,10 @@ local function openidc_authorization_response(opts, session)
     log(ERROR, err)
     return nil, err, session.data.original_url, session
   end
-
+  
+  -- ensure that discovered data is resolved
+  openidc_ensure_discovered_data(opts)
+  
   -- check the iss if returned from the OP
   if args.iss and args.iss ~= opts.discovery.issuer then
     err = "iss from argument: " .. args.iss .. " does not match expected issuer: " .. opts.discovery.issuer


### PR DESCRIPTION
When running against a Discovery-url I get the following error:

```
2018/11/05 14:30:58 [error] 30#30: *1 lua entry thread aborted: runtime error: /usr/local/openresty/luajit/share/lua/5.1/resty/openidc.lua:1007: attempt to concatenate field 'issuer' (a nil value)
```
When running  `openidc_ensure_discovered_data(opts)` before the check inside the function `openidc_authorization_response` that seem to fix the problem.