### PR TITLE
reuse session data during authentication if session data is available

### DIFF
--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -315,9 +315,20 @@ local function openidc_authorize(opts, session, target_url, prompt)
   local resty_string = require("resty.string")
 
   -- generate state and nonce
-  local state = resty_string.to_hex(resty_random.bytes(16))
-  local nonce = (opts.use_nonce == nil or opts.use_nonce)
-    and resty_string.to_hex(resty_random.bytes(16))
+  local state = nil
+  if (session.data.state == nil) then
+    state = resty_string.to_hex(resty_random.bytes(16))
+  else
+    state = session.data.state
+  end
+
+  local nonce = nil
+  if (session.data.nonce == nil) then
+    nonce = (opts.use_nonce == nil or opts.use_nonce)
+      and resty_string.to_hex(resty_random.bytes(16))
+  else
+    nonce = session.data.nonce
+  end
 
   -- assemble the parameters to the authentication request
   local params = {


### PR DESCRIPTION
Hi, I've been using this module in my application and stumbled across a problem.
I thought of using this PR to provide both a description of the problem as well as a possible fix for it.

How to reproduce the problem:
1. In browser window 1 open an application URL which requires authentication.
2. In browser window 2 open an application URL which requires authentication.
3. Return to window 1 and complete the login.
4. "This site can’t be reached" error is displayed on the screen.

The problem is to do with the fact that during authorization, the session data state and nonce always get refreshed.
This causes the following error message in openresty:

`2019/04/08 13:43:15 [error] 7#7: *1 [lua] openidc.lua:1055: authenticate(): state from argument: abcd does not match state restored from session: bcde`

In order to fix this problem, if the session data state and nonce are available (browser window 1 in the example will cause it to be available), then it should not be updated with new values when a new authorization request is performed (browser window 2 from the example).