### PR TITLE
added error handling when opening session.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+04/23/2019
+- error handling when starting session
+
 03/18/2019
 - fixed accidental use of global variable err in revoke_tokens_on_logout;
   see #253, #254; thanks @arcivanov

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1350,7 +1350,11 @@ function openidc.authenticate(opts, target_url, unauth_action, session_opts)
 
   local err
 
-  local session = r_session.start(session_opts)
+  local session, session_error = r_session.start(session_opts)
+  if session == nil then
+    log(ERROR, "Error starting session: " .. session_error)
+    return nil, session_error, target_url, session
+  end
 
   target_url = target_url or ngx.var.request_uri
 


### PR DESCRIPTION
session start fails if storage adapter host is not accessible (set $session_storage memcache/redis;)

improved message in logs will be as following:
2019/04/23 08:00:06 [error] 21#21: *1 [lua] openidc.lua:1344: authenticate(): Error starting session: memcache.local could not be resolved (3: Host not found)

instead of current unclear message: attempt to index local 'session' (a nil value)