### PR TITLE
Allow OPM installation with newer lua-resty-http versions

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -4,4 +4,4 @@ author = Hans Zandbelt (@zandbelt)
 is_original = yes
 license = apache2
 repo_link = https://github.com/zmartzone/lua-resty-openidc
-requires = openresty, pintsized/lua-resty-http >= 0.08, bungle/lua-resty-session >= 2.8, cdbattags/lua-resty-jwt >= 0.2.0
+requires = openresty, ledgetech/lua-resty-http >= 0.13, bungle/lua-resty-session >= 2.8, cdbattags/lua-resty-jwt >= 0.2.0


### PR DESCRIPTION
The `pintsized/lua-resty-http` git repo was [renamed](https://github.com/ledgetech/lua-resty-http/commit/f71e9708a3fd0ff4179d4b0d770c91fcf98d0042#diff-a580a87ff9da14b51504d149be8ecaff) to `ledgetech/lua-resty-http` for the 0.13 release. The repo now also redirects from "pintsized" to "ledgetech" on github.com: https://github.com/pintsized/lua-resty-http

This switches the OPM dependency to the new repo name. Without this, you can't install lua-resty-openidc if you already have the newer `pintsized/lua-resty-http` OPM package installed, due to package conflicts:

```
$ opm get ledgetech/lua-resty-http
* Fetching ledgetech/lua-resty-http  
  Downloading https://opm.openresty.org/api/pkg/tarball/ledgetech/lua-resty-http-0.14.opm.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 20862  100 20862    0     0  32597      0 --:--:-- --:--:-- --:--:-- 32596
Package ledgetech/lua-resty-http 0.14 installed successfully under /usr/local/openresty/site/ .


$ opm get zmartzone/lua-resty-openidc
* Fetching zmartzone/lua-resty-openidc  
  Downloading https://opm.openresty.org/api/pkg/tarball/zmartzone/lua-resty-openidc-1.7.2.opm.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 30393  100 30393    0     0   126k      0 --:--:-- --:--:-- --:--:--  126k
ERROR: failed to install pintsized/lua-resty-http: ledgetech/lua-resty-http 0.14 already installed.
```
