### PR TITLE
Close session

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,3 +32,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Oleander Reis <https://github.com/oleeander>
 	Michael Johansen <https://github.com/mijohansen>
 	Joshua Erney <https://github.com/JoshTheGoldfish>
+	Andrei Bastun <https://github.com/vershnik>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+09/20/2019
+- session started with session.start must be closed in order to release lock
+
 07/15/2019
 - release 1.7.2
 


### PR DESCRIPTION
lua-resty-session v2.24 fixed a bug in session locking mechanism, so now storages with locking support can be used in resty
