### PR TITLE
Refresh failed pass

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,3 +32,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Oleander Reis <https://github.com/oleeander>
 	Michael Johansen <https://github.com/mijohansen>
 	Joshua Erney <https://github.com/JoshTheGoldfish>
+	Nick Wiedenbrueck <https://github.com/cretzel>

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1429,7 +1429,7 @@ function openidc.authenticate(opts, target_url, unauth_action, session_opts)
     if unauth_action == "pass" then
       if token_expired then
         session.data.authenticated = false
-        return nil, 'unauthorized request', target_url, session
+        return nil, 'token refresh failed', target_url, session
       end
       return nil, err, target_url, session
     end

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1427,6 +1427,10 @@ function openidc.authenticate(opts, target_url, unauth_action, session_opts)
       or opts.force_reauthorize
       or (try_to_renew and token_expired) then
     if unauth_action == "pass" then
+      if token_expired then
+        session.data.authenticated = false
+      end
+
       return
       nil,
       err,

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1429,20 +1429,12 @@ function openidc.authenticate(opts, target_url, unauth_action, session_opts)
     if unauth_action == "pass" then
       if token_expired then
         session.data.authenticated = false
+        return nil, 'unauthorized request', target_url, session
       end
-
-      return
-      nil,
-      err,
-      target_url,
-      session
+      return nil, err, target_url, session
     end
     if unauth_action == 'deny' then
-      return
-      nil,
-      'unauthorized request',
-      target_url,
-      session
+      return nil, 'unauthorized request', target_url, session
     end
 
     err = ensure_config(opts)


### PR DESCRIPTION
Problem: When unauth_action is "pass" and refresh of token fails, e.g. because refresh token has expired, then the session attribute "authenticated" is still true. In this case the request will be passed, although the user is not authenticated.

Setting session.data.authenticated to false and returning an error will allow a client to detect, if the refresh was successful.