### PR TITLE
Adds handlers to openidc_combine_uri to handle code challenge fields

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,3 +33,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Michael Johansen <https://github.com/mijohansen>
 	Joshua Erney <https://github.com/JoshTheGoldfish>
 	Nick Wiedenbrueck <https://github.com/cretzel>
+	Frank Cash <https://github.com/frankcash>

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -341,6 +341,14 @@ local function openidc_authorize(opts, session, target_url, prompt)
     params.display = opts.display
   end
 
+	if opts.code_challenge_method then
+		params.code_challenge_method = opts.code_challenge_method
+	end
+
+	if opts.code_challenge then
+		params.code_challenge = opts.code_challenge
+	end
+
   -- merge any provided extra parameters
   if opts.authorization_params then
     for k, v in pairs(opts.authorization_params) do params[k] = v end


### PR DESCRIPTION
# Summary

`lua-resty-openidc` will now check to see if `code_challenge` and `code_challenge_method` are populated. if they are populated they will be added to the uri.

This is for [Proof Key for Code Exchange (PKCE)](https://oauth.net/2/pkce/) authorization flows.

## Related Ticket

Addresses #291 

## Describe the changes in behavior

### Previous Behavior

`<open_api>/authorize?response_type=code&client_id=<client_id>&state=00d7e5b7b4a4847d882218f90245f73b&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&nonce=7f2671dcffae4ca05ecd2686144ac120&scope=openid%20email%20profile`

### New Behavior:
`<open_api>/authorize?response_type=code&client_id=<client_id>&state=b46715da32d0e26a068427496f501610&code_challenge=<challenge>&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&code_challenge_method=<method>&nonce=25b6fc3e087302288fdb06eb9406f0cc&scope=openid%20email%20profile, client`