### PR TITLE
Ability to disable keepalive

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,3 +33,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Michael Johansen <https://github.com/mijohansen>
 	Joshua Erney <https://github.com/JoshTheGoldfish>
 	Nick Wiedenbrueck <https://github.com/cretzel>
+        Eduardo Gonçalves <https://github.com/Dudssource>

--- a/AUTHORS
+++ b/AUTHORS
@@ -33,4 +33,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Michael Johansen <https://github.com/mijohansen>
 	Joshua Erney <https://github.com/JoshTheGoldfish>
 	Nick Wiedenbrueck <https://github.com/cretzel>
-        Eduardo Gonçalves <https://github.com/Dudssource>
+	Eduardo Gonçalves <https://github.com/Dudssource>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+02/06/2020
+- ability to disable keepalive from lua-resty-http
+  By disabling keepalive we disable the native connection pool,
+  avoiding errors when dealing with invalid connections. This is 
+  specially useful when proxying ajax requests.
+
 02/05/2020
 - no longer echo the URI parameters back on default error page when
   OIDC provider returns an error in call to redirect_uri; see #306;

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ h2JHukolz9xf6qN61QMLSd83+kwoBr2drp6xg3eGDLIkQCQLrkY=
              --client_jwt_assertion_expires_in = 60,
              -- When using https to any OP endpoints, enforcement of SSL certificate check can be mandated ("yes") or not ("no").
              --ssl_verify = "no",
+             -- Connection keepalive with the OP can be enabled ("yes") or disabled ("no").
+             --keepalive = "no",
 
              --authorization_params = { hd="zmartzone.eu" },
              --scope = "openid email profile",

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -496,7 +496,7 @@ function openidc.call_token_endpoint(opts, endpoint, body, auth, endpoint_name, 
     body = ngx.encode_args(body),
     headers = headers,
     ssl_verify = (opts.ssl_verify ~= "no"),
-    keepalive = false
+    keepalive = (opts.keepalive ~= "no")
   }))
   if not res then
     err = "accessing " .. ep_name .. " endpoint (" .. endpoint .. ") failed: " .. err
@@ -529,7 +529,7 @@ function openidc.call_userinfo_endpoint(opts, access_token)
                                      decorate_request(opts.http_request_decorator, {
     headers = headers,
     ssl_verify = (opts.ssl_verify ~= "no"),
-    keepalive = false
+    keepalive = (opts.keepalive ~= "no")
   }))
   if not res then
     err = "accessing (" .. opts.discovery.userinfo_endpoint .. ") failed: " .. err
@@ -563,7 +563,7 @@ local function openidc_load_jwt_none_alg(enc_hdr, enc_payload)
 end
 
 -- get the Discovery metadata from the specified URL
-local function openidc_discover(url, ssl_verify, timeout, exptime, proxy_opts, http_request_decorator)
+local function openidc_discover(url, ssl_verify, keepalive, timeout, exptime, proxy_opts, http_request_decorator)
   log(DEBUG, "openidc_discover: URL is: " .. url)
 
   local json, err
@@ -577,7 +577,7 @@ local function openidc_discover(url, ssl_verify, timeout, exptime, proxy_opts, h
     openidc_configure_proxy(httpc, proxy_opts)
     local res, error = httpc:request_uri(url, decorate_request(http_request_decorator, {
       ssl_verify = (ssl_verify ~= "no"),
-      keepalive = false
+      keepalive = (keepalive ~= "no")
     }))
     if not res then
       err = "accessing discovery url (" .. url .. ") failed: " .. error
@@ -605,7 +605,7 @@ local function openidc_ensure_discovered_data(opts)
   local err
   if type(opts.discovery) == "string" then
     local discovery
-    discovery, err = openidc_discover(opts.discovery, opts.ssl_verify, opts.timeout, opts.jwk_expires_in, opts.proxy_opts,
+    discovery, err = openidc_discover(opts.discovery, opts.ssl_verify, opts.keepalive, opts.timeout, opts.jwk_expires_in, opts.proxy_opts,
                                       opts.http_request_decorator)
     if not err then
       opts.discovery = discovery
@@ -689,7 +689,7 @@ function openidc.get_discovery_doc(opts)
   return opts.discovery, err
 end
 
-local function openidc_jwks(url, force, ssl_verify, timeout, exptime, proxy_opts, http_request_decorator)
+local function openidc_jwks(url, force, ssl_verify, keepalive, timeout, exptime, proxy_opts, http_request_decorator)
   log(DEBUG, "openidc_jwks: URL is: " .. url .. " (force=" .. force .. ") (decorator=" .. (http_request_decorator and type(http_request_decorator) or "nil"))
 
   local json, err, v
@@ -707,7 +707,7 @@ local function openidc_jwks(url, force, ssl_verify, timeout, exptime, proxy_opts
     openidc_configure_proxy(httpc, proxy_opts)
     local res, error = httpc:request_uri(url, decorate_request(http_request_decorator, {
       ssl_verify = (ssl_verify ~= "no"),
-      keepalive = false
+      keepalive = (keepalive ~= "no")
     }))
     if not res then
       err = "accessing jwks url (" .. url .. ") failed: " .. error
@@ -865,7 +865,7 @@ local function openidc_pem_from_jwk(opts, kid)
   local jwk, jwks
 
   for force = 0, 1 do
-    jwks, err = openidc_jwks(opts.discovery.jwks_uri, force, opts.ssl_verify, opts.timeout, opts.jwk_expires_in, opts.proxy_opts,
+    jwks, err = openidc_jwks(opts.discovery.jwks_uri, force, opts.ssl_verify, opts.keepalive, opts.timeout, opts.jwk_expires_in, opts.proxy_opts,
                              opts.http_request_decorator)
     if err then
       return nil, err

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -495,7 +495,8 @@ function openidc.call_token_endpoint(opts, endpoint, body, auth, endpoint_name, 
     method = "POST",
     body = ngx.encode_args(body),
     headers = headers,
-    ssl_verify = (opts.ssl_verify ~= "no")
+    ssl_verify = (opts.ssl_verify ~= "no"),
+    keepalive = false
   }))
   if not res then
     err = "accessing " .. ep_name .. " endpoint (" .. endpoint .. ") failed: " .. err
@@ -527,7 +528,8 @@ function openidc.call_userinfo_endpoint(opts, access_token)
   local res, err = httpc:request_uri(opts.discovery.userinfo_endpoint,
                                      decorate_request(opts.http_request_decorator, {
     headers = headers,
-    ssl_verify = (opts.ssl_verify ~= "no")
+    ssl_verify = (opts.ssl_verify ~= "no"),
+    keepalive = false
   }))
   if not res then
     err = "accessing (" .. opts.discovery.userinfo_endpoint .. ") failed: " .. err
@@ -574,7 +576,8 @@ local function openidc_discover(url, ssl_verify, timeout, exptime, proxy_opts, h
     openidc_configure_timeouts(httpc, timeout)
     openidc_configure_proxy(httpc, proxy_opts)
     local res, error = httpc:request_uri(url, decorate_request(http_request_decorator, {
-      ssl_verify = (ssl_verify ~= "no")
+      ssl_verify = (ssl_verify ~= "no"),
+      keepalive = false
     }))
     if not res then
       err = "accessing discovery url (" .. url .. ") failed: " .. error
@@ -703,7 +706,8 @@ local function openidc_jwks(url, force, ssl_verify, timeout, exptime, proxy_opts
     openidc_configure_timeouts(httpc, timeout)
     openidc_configure_proxy(httpc, proxy_opts)
     local res, error = httpc:request_uri(url, decorate_request(http_request_decorator, {
-      ssl_verify = (ssl_verify ~= "no")
+      ssl_verify = (ssl_verify ~= "no"),
+      keepalive = false
     }))
     if not res then
       err = "accessing jwks url (" .. url .. ") failed: " .. error

--- a/tests/spec/test_support.lua
+++ b/tests/spec/test_support.lua
@@ -18,7 +18,8 @@ local DEFAULT_OIDC_CONFIG = {
    },
    client_id = "client_id",
    client_secret = "client_secret",
-   ssl_verify = "no"
+   ssl_verify = "no",
+   keepalive = "yes"
 }
 
 local DEFAULT_ID_TOKEN = {


### PR DESCRIPTION
Hello everyone,
In one of our customers, we use this (amazing) library to behave like a lightweight and fast oidc reverse proxy (deployed as a k8s sidecar along with SPA applications).
To be able to proxy page requests and also ajax requests, we configured the proxy to have two default actions (for non authenticated requests): 

- For ajax requests we deny every request that has failed to **authenticate**
- For page requests we don't specify an action (nil), redirecting to the OP if the requests it's not already logged in

However, after some time we started to notice intermittent failures with the ajax requests. The request failed but the session was valid (so it wasn't because HTTP session expiration, SSO session revoked, etc.).

On the openresty logs we found this error:

`2020/02/06 18:32:57 [error] 8#8: *11162 [lua] openidc.lua:1406: authenticate(): lost access token:accessing token endpoint (https://sso.acme.com/auth/realms/realm/protocol/openid-connect/token) failed: closed, client: x.x.x.x, server: frontend.project.svc, request: "GET / HTTP/1.1", host: "frontend.acme.com", referrer: "https://frontend.acme.com/api"`

After some research we figured out that the lua-resty-openidc uses a library called lua-resty-http to make calls to the OP.

This library (lua-resty-http) by default enables keepalive on the connections so it can create a connection pool to cache and reuse them later. This is necessary for a lot of good reasons (mostly performance related), but for some cases this behaviour can generate this issues, because the connection eventually will be closed and in my case this intermittent errors caused unnecessary api retries and extra traffic.

The idea of this PR is to make it possible for the user to enable or disable keepalive on the lua-resty-http library (just like the ssl_verify option).

The default behaviour would be to keep the keepalive enabled, to avoid causing problems with other users.

Regards,