### PR TITLE
Fix default expiration-time of jwks and discovery urls caches.

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,8 +380,8 @@ lAc5Csj0o5Q+oEhPUAVBIF07m4rd0OvAVPOCQ2NJhQSL1oWASbf+fg==
              -- verified at all.
              --accept_unsupported_alg = true
 
-             -- the expiration time in seconds for jwk cache, default is 1 day.
-             --jwk_expires_in = 24 * 60 * 60
+             -- the expiration time in 0.001 seconds for jwk cache, default is 1 day.
+             --jwk_expires_in = 24 * 60 * 60 * 1000
 
           }
 

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -586,7 +586,7 @@ local function openidc_discover(url, ssl_verify, keepalive, timeout, exptime, pr
       log(DEBUG, "response data: " .. res.body)
       json, err = openidc_parse_json_response(res)
       if json then
-        openidc_cache_set("discovery", url, cjson.encode(json), exptime or 24 * 60 * 60)
+        openidc_cache_set("discovery", url, cjson.encode(json), exptime or 24 * 60 * 60 * 1000)
       else
         err = "could not decode JSON from Discovery data" .. (err and (": " .. err) or '')
         log(ERROR, err)
@@ -716,7 +716,7 @@ local function openidc_jwks(url, force, ssl_verify, keepalive, timeout, exptime,
       log(DEBUG, "response data: " .. res.body)
       json, err = openidc_parse_json_response(res)
       if json then
-        openidc_cache_set("jwks", url, cjson.encode(json), exptime or 24 * 60 * 60)
+        openidc_cache_set("jwks", url, cjson.encode(json), exptime or 24 * 60 * 60 * 1000)
       end
     end
 
@@ -892,7 +892,7 @@ local function openidc_pem_from_jwk(opts, kid)
     return nil, "don't know how to create RSA key/cert for " .. cjson.encode(jwk)
   end
 
-  openidc_cache_set("jwks", cache_id, pem, opts.jwk_expires_in or 24 * 60 * 60)
+  openidc_cache_set("jwks", cache_id, pem, opts.jwk_expires_in or 24 * 60 * 60 * 1000)
   return pem
 end
 


### PR DESCRIPTION
Fix default expiration-time of jwks and discovery urls caches.

The expiration time is measured in 0.001 seconds, according to [https://openresty-reference.readthedocs.io/en/latest/Lua_Nginx_API/#ngxshareddictset](https://openresty-reference.readthedocs.io/en/latest/Lua_Nginx_API/#ngxshareddictset)

Hence, currently jwks and discovery were only cache for 86.4 seconds instead of full day.
=> Replace 24 * 60 * 60 with 24 * 60 * 60 * 1000 in default cache expiration.