### PR TITLE
Add custom_params options to allow custom parameters

### DIFF
--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -329,6 +329,10 @@ local function openidc_authorize(opts, session, target_url, prompt)
     state = state,
   }
 
+  if opts.custom_params then
+    for k,v in pairs(opts.custom_params) do params[k] = v end
+  end
+
   if nonce then
     params.nonce = nonce
   end


### PR DESCRIPTION
Using google as openid connect provider a google custom parameter is needed to get refresh_token.

https://developers.google.com/identity/protocols/oauth2/openid-connect#access-type-param

I bet each connect provider may have its own custom parameters so it could be useful to add an optional custom parameters table to this lua-resty-openidc options library.

For example using google to get a refresh_token:
```lua
local opts = {
  [...]
  custom_params = {
    access_type = "offline",
  },
  [...]
}
```