### PR TITLE
Reuse login sessions and ignore following logins

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,18 @@ h2JHukolz9xf6qN61QMLSd83+kwoBr2drp6xg3eGDLIkQCQLrkY=
 
              --use_nonce = false
              -- By default the authorization request includes the
-             -- nonce paramter. You can use this option to disable it
+             -- nonce parameter. You can use this option to disable it
              -- which may be necessary when talking to a broken OpenID
-             -- Connect provider that ignores the paramter as the
+             -- Connect provider that ignores the parameter as the
              -- id_token will be rejected otherwise.
+
+             --reuse_existing_login_sessions = true
+             -- By default a new session and nonce is generated every time authorization is (re)started, invalidating previously open login tabs.
+             -- However, an existing session can be reused so all the previously opened login tabs are valid
+
+             --ignore_following_logins = true
+             -- By default if user logins when already logged, this second login will throw an error because state/nonce we wiped by the first login
+             -- By setting the parameter to true, following logins would be ignored and will redirect user to return url
 
              --revoke_tokens_on_logout = false
              -- When revoke_tokens_on_logout is set to true a logout notifies the authorization server that previously obtained refresh and access tokens are no longer needed. This requires that revocation_endpoint is discoverable.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ h2JHukolz9xf6qN61QMLSd83+kwoBr2drp6xg3eGDLIkQCQLrkY=
              --  Expiration leeway for access_token renewal. If this is set, renewal will happen access_token_expires_leeway seconds before the token expiration. This avoids errors in case the access_token just expires when arriving to the OAuth Resource Server.
 
              --force_reauthorize = false
-             -- When force_reauthorize is set to true the authorization flow will be executed even if a token has been cached already
+             -- When force_reauthorize is set to true the authorization flow will be executed even if a token has been cached already. 
+             -- If set, will override `reuse_existing_login_sessions` option.
+
              --session_contents = {id_token=true}
              -- Whitelist of session content to enable. This can be used to reduce the session size.
              -- When not set everything will be included in the session.
@@ -201,6 +203,7 @@ h2JHukolz9xf6qN61QMLSd83+kwoBr2drp6xg3eGDLIkQCQLrkY=
              --reuse_existing_login_sessions = true
              -- By default a new session and nonce is generated every time authorization is (re)started, invalidating previously open login tabs.
              -- However, an existing session can be reused so all the previously opened login tabs are valid
+             -- Will be ignored when `force_reauthorize` option is set.
 
              --ignore_following_logins = true
              -- By default if user logins when already logged, this second login will throw an error because state/nonce we wiped by the first login

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -335,7 +335,7 @@ local function openidc_authorize(opts, session, target_url, prompt)
   local code_verifier = opts.use_pkce and openidc_base64_url_encode(resty_random.bytes(32))
 
   -- reuse existing session state/nonce so all already opened login tabs are valid
-  if opts.reuse_existing_login_sessions and session and session.data.state then
+  if not opts.force_reauthorize and opts.reuse_existing_login_sessions and session and session.data.state then
     state = session.data.state
     if use_nonce and session.data.nonce then
       nonce = session.data.nonce
@@ -1085,7 +1085,7 @@ local function openidc_authorization_response(opts, session)
   local args = ngx.req.get_uri_args()
   local err, log_err, client_err
 
-  if (opts.ignore_following_logins and session and session.data.authenticated and session.data.original_url) then
+  if (opts.ignore_following_logins and session and session.data.authenticated and session.data.original_url and ngx.time() < session.data.access_token_expiration) then
     ngx.redirect(session.data.original_url)
   end
 


### PR DESCRIPTION
This merge request consists of two small addons intended to improve user experience when having two or more opened login tabs.

---

When `reuse_existing_login_sessions` is set to `true`, the plugin will reuse existing state/nonce which keeps previously opened login tabs valid. 

Currently, all the previously opened login tabs are invalidated as soon as a new tab is opened. This is, for example, an issue when user has multiple tabs with the app opened and is automatically logged out after some inactivity. Then he has a few login tabs but only one has a valid state/nonce. With this fix, all the login tabs are working. 

---

When `ignore_following_logins` is set to `true`, the plugin will ignore successful logins when user is already logged in the app and forward to the app directly, keeping the current login session. 

Currently, if user logins into the app while being logged (for example, by logging in in some old login tab), the plugin returns a error and user is forwarded to a login screen again. With the fix enabled, user is flawlessly redirected back to the application without noticing anything strange. 

---

By default, both parameters are unset so current old behavior stays untouched.