### PR TITLE
Update test  Dockerfile image

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM openresty/openresty:xenial
+FROM openresty/openresty:bionic
 
 # install dependencies
 RUN ["luarocks", "install", "lua-resty-session"]


### PR DESCRIPTION
The `xenial` image is not accessible anymore, returns 404. Instead, I've changed to `bionic` to execute tests inside docker.