### PR TITLE
Update lua-resty-jwt version

### DIFF
--- a/lua-resty-openidc-1.7.3-1.rockspec
+++ b/lua-resty-openidc-1.7.3-1.rockspec
@@ -25,7 +25,7 @@ dependencies = {
     "lua >= 5.1",
     "lua-resty-http >= 0.08",
     "lua-resty-session >= 2.8",
-    "lua-resty-jwt == 0.2.0"
+    "lua-resty-jwt == 0.2.2"
 }
 build = {
     type = "builtin",


### PR DESCRIPTION
The dependency  `lua-resty-jwt:0.2.0` is related with [this issue](https://github.com/nokia/kong-oidc/issues/157), fixed in the version `0.2.2`.

Output of the related error:
```
kong_1         | 2020/10/21 07:20:24 [error] 22#0: *1020 lua coroutine: runtime error: /usr/local/share/lua/5.1/resty/hmac.lua:81: size of C type is unknown or too large at line 44
kong_1         | stack traceback:
kong_1         | coroutine 0:
kong_1         | 	[C]: in function 'require'
kong_1         | 	/usr/local/share/lua/5.1/resty/openidc.lua:954: in function 'openidc_load_jwt_and_verify_crypto'
kong_1         | 	/usr/local/share/lua/5.1/resty/openidc.lua:1041: in function 'openidc_load_and_validate_jwt_id_token'
```
