### PR TITLE
try to avoid cache confusion

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,9 +2,10 @@
 - if lifecyle handlers return truthy values they cause the operation
   they are handlers of to fail; see #384; thanks to @arcivanov
 
-09/19/2021
-- made jwt_verify() and bearer_jwt_verify() honor
-  opts.introspection_cache_ignore as well.
+09/22/2021
+- made jwt_verify() and bearer_jwt_verify() use a separate cache named
+  "jwt_verification" and introduced opts.jwt_verification_cache_ignore
+  to disable caching completely
 
 12/05/2020
 - fixed a session leak in access_token() and for a very unlikely

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,10 +2,13 @@
 - if lifecyle handlers return truthy values they cause the operation
   they are handlers of to fail; see #384; thanks to @arcivanov
 
+- added opts.cache_segment as option to shard the cache used by token
+  introspection or JWT verification; see #399
+
 09/22/2021
 - made jwt_verify() and bearer_jwt_verify() use a separate cache named
   "jwt_verification" and introduced opts.jwt_verification_cache_ignore
-  to disable caching completely
+  to disable caching completely; see #399
 
 12/05/2020
 - fixed a session leak in access_token() and for a very unlikely

--- a/README.md
+++ b/README.md
@@ -299,6 +299,16 @@ local res, err, target, session = require("resty.openidc").authenticate(opts)
 session:close()
 ```
 
+## Caching of Introspection and JWT Verification Results
+
+Note the `jwt_verification` and `introspection` caches are shared
+between all configured locations. If you are using locations with
+different `opts` configuration the shared cache may allow a token that
+is valid for only one location to be accepted by another if it is read
+from the cache. In order to avoid cache confusion it is recommended to
+set `opts.cache_segment` to unique strings for each set of related
+locations.
+
 ## Sample Configuration for OAuth 2.0 JWT Token Validation
 
 Sample `nginx.conf` configuration for verifying Bearer JWT Access Tokens against a pre-configured secret/key.
@@ -379,6 +389,10 @@ lAc5Csj0o5Q+oEhPUAVBIF07m4rd0OvAVPOCQ2NJhQSL1oWASbf+fg==
              -- It may be necessary to force verification for a bearer token and ignore the existing cached
              -- verification results. If so you need to set set the jwt_verification_cache_ignore option to true.
              -- jwt_verification_cache_ignore = true
+
+             -- optional name of a cache-segment if you need separate
+             -- caches for differently configured locations
+             -- cache_segment = 'api'
           }
 
           -- call bearer_jwt_verify for OAuth 2.0 JWT validation
@@ -447,6 +461,10 @@ http {
              -- Defaults to "exp" - Controls the TTL of the introspection cache
              -- https://tools.ietf.org/html/rfc7662#section-2.2
              -- introspection_expiry_claim = "exp"
+
+             -- optional name of a cache-segment if you need separate
+             -- caches for differently configured locations
+             -- cache_segment = 'api'
           }
 
           -- call introspect for OAuth 2.0 Bearer Access Token validation
@@ -547,6 +565,10 @@ http {
              -- It may be necessary to force an introspection call for an access_token and ignore the existing cached
              -- introspection results. If so you need to set set the introspection_cache_ignore option to true.
              -- introspection_cache_ignore = true
+
+             -- optional name of a cache-segment if you need separate
+             -- caches for differently configured locations
+             -- cache_segment = 'api'
           }
 
           -- call introspect for OAuth 2.0 Bearer Access Token validation

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ http {
   resolver 8.8.8.8;
 
   # cache for JWT verification results
-  lua_shared_dict introspection 10m;
+  lua_shared_dict jwt_verification 10m;
 
   server {
     listen 8080;
@@ -376,9 +376,9 @@ lAc5Csj0o5Q+oEhPUAVBIF07m4rd0OvAVPOCQ2NJhQSL1oWASbf+fg==
              -- the expiration time in seconds for jwk cache, default is 1 day.
              --jwk_expires_in = 24 * 60 * 60
 
-             -- It may be necessary to force an introspection call for a bearer token and ignore the existing cached
-             -- introspection results. If so you need to set set the introspection_cache_ignore option to true.
-             -- introspection_cache_ignore = true
+             -- It may be necessary to force verification for a bearer token and ignore the existing cached
+             -- verification results. If so you need to set set the jwt_verification_cache_ignore option to true.
+             -- jwt_verification_cache_ignore = true
           }
 
           -- call bearer_jwt_verify for OAuth 2.0 JWT validation

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1629,7 +1629,8 @@ local function get_introspection_endpoint(opts)
 end
 
 local function get_introspection_cache_prefix(opts)
-  return (get_introspection_endpoint(opts) or 'nil-endpoint') .. ','
+  return (opts.cache_segment and opts.cache_segment.gsub(',', '_') or 'DEFAULT') .. ','
+    .. (get_introspection_endpoint(opts) or 'nil-endpoint') .. ','
     .. (opts.client_id or 'no-client_id') .. ','
     .. (opts.client_secret and 'secret' or 'no-client_secret') .. ':'
 end
@@ -1738,7 +1739,8 @@ local function get_jwt_verification_cache_prefix(opts)
   for _, alg in ipairs(expected_algs) do
     signing_alg_values_expected = signing_alg_values_expected .. ',' .. alg
   end
-  return (opts.public_key or 'no-pubkey') .. ','
+  return (opts.cache_segment and opts.cache_segment.gsub(',', '_') or 'DEFAULT') .. ','
+    .. (opts.public_key or 'no-pubkey') .. ','
     .. (opts.symmetric_key or 'no-symkey') .. ','
     .. signing_alg_values_expected .. ':'
 end


### PR DESCRIPTION
closes #399 

If you've got two differently configured locations the cache may allow tokens accepted by one location to be used at a different one - even if they would not be valid for the other location's configuration.

This PR does three things:

* separate the caches for JWT verification and token introspection
* use some of the configuration settings of opts as part of the cache key. I later realized this is probably futile so I added explicit configuration via the third step
* adds an option to segregate the cache by assigning a "segment" to a set of related locations

@zandbelt I'm not sure whether we want to leave in the second part at all or just stick with the user-controlled configuration.