### PR TITLE
Make revoke_token() accessible

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,3 +34,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Joshua Erney <https://github.com/JoshTheGoldfish>
 	Nick Wiedenbrueck <https://github.com/cretzel>
 	Eduardo Gonçalves <https://github.com/Dudssource>
+	Thorsten Fleischmann <https://github.com/thorstenfleischmann>

--- a/README.md
+++ b/README.md
@@ -309,6 +309,12 @@ from the cache. In order to avoid cache confusion it is recommended to
 set `opts.cache_segment` to unique strings for each set of related
 locations.
 
+## Revoke tokens
+
+The `revoke_tokens(opts, session)` function revokes the current refresh and access token. In contrast to a full logout, the session cookie will not be destroyed and the endsession endpoint will not be called. The function returns `true` if both tokens were revoked successfully. This function might be helpful in scenarios where you want to destroy/remove a session from the server side.
+
+With `revoke_token(opts, token_type_hint, token)` it is also possible to revoke a specific token. `token_type_hint` can usually be `refresh_token` or `access_token`.
+
 ## Sample Configuration for OAuth 2.0 JWT Token Validation
 
 Sample `nginx.conf` configuration for verifying Bearer JWT Access Tokens against a pre-configured secret/key.

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1238,7 +1238,7 @@ end
 function openidc.revoke_token(opts, token_type_hint, token)
   local err = openidc_ensure_discovered_data(opts)
   if err then
-    log(ERROR, "revocation of " .. token_type_hint .. " unsuccessful: " .. err)
+    log(ERROR, "revocation of " .. (token_type_hint or "token (no type specified)") .. " unsuccessful: " .. err)
     return false
   end
 

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1234,6 +1234,36 @@ local function openidc_revoke_token(opts, token_type_hint, token)
   end
 end
 
+function openidc.revoke_token(opts, token_type_hint, token)
+  local err = openidc_ensure_discovered_data(opts)
+  if err then
+    log(ERROR, "revocation of " .. token_type_hint .. " unsuccessful: " .. err)
+    return false
+  end
+
+  return openidc_revoke_token(opts, token_type_hint, token)
+end
+
+function openidc.revoke_tokens(opts, session)
+  local err = openidc_ensure_discovered_data(opts)
+  if err then
+    log(ERROR, "revocation of tokens unsuccessful: " .. err)
+    return false
+  end
+
+  local access_token = session.data.access_token
+  local refresh_token = session.data.refresh_token
+
+  local access_token_revoke, refresh_token_revoke
+  if refresh_token then
+    access_token_revoke = openidc_revoke_token(opts, "refresh_token", refresh_token)
+  end
+  if access_token then
+    refresh_token_revoke = openidc_revoke_token(opts, "access_token", access_token)
+  end
+  return access_token_revoke and refresh_token_revoke
+end
+
 local openidc_transparent_pixel = "\137\080\078\071\013\010\026\010\000\000\000\013\073\072\068\082" ..
     "\000\000\000\001\000\000\000\001\008\004\000\000\000\181\028\012" ..
     "\002\000\000\000\011\073\068\065\084\120\156\099\250\207\000\000" ..

--- a/tests/spec/revoke_tokens_spec.lua
+++ b/tests/spec/revoke_tokens_spec.lua
@@ -1,0 +1,31 @@
+local http = require('socket.http')
+local test_support = require('test_support')
+require 'busted.runner'()
+
+describe('when revoke_tokens is successful', function()
+  test_support.start_server({
+    oidc_opts = {
+      discovery = {
+        revocation_endpoint = "http://127.0.0.1/revocation",
+      }
+    }
+  })
+  teardown(test_support.stop_server)
+  local _, _, cookies = test_support.login()
+  local content_table = {}
+  http.request({
+      url = "http://localhost/revoke_tokens",
+      headers = { cookie = cookies },
+      sink = ltn12.sink.table(content_table)
+    })
+
+  it('should return true', function()
+    assert.are.equals("revoke-result: true\n", table.concat(content_table))
+  end)
+
+  it('should have logged the revocation', function()
+    assert.error_log_contains("revocation of refresh_token successful")
+    assert.error_log_contains("revocation of access_token successful")
+  end)
+
+end)

--- a/tests/spec/test_support.lua
+++ b/tests/spec/test_support.lua
@@ -372,6 +372,16 @@ JWT_SIGN_SECRET]=]
             }
         }
 
+        location /revoke_tokens {
+          content_by_lua_block {
+              local opts = OIDC_CONFIG
+              local res, err, target, session = oidc.authenticate(opts, nil, UNAUTH_ACTION)
+              local r = oidc.revoke_tokens(opts, session)
+              ngx.header.content_type = 'text/plain'
+              ngx.say('revoke-result: ' .. tostring(r))
+          }
+        }
+
         location /revocation {
             content_by_lua_block {
                 ngx.req.read_body()


### PR DESCRIPTION
New function revoke_token() and revoke_tokens()

Enables the usage of revoke_token() for use cases which needs token revocation without logout.

