### PR TITLE
Bug when calling bearer_jwt_verify with cache_segment

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,3 +35,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Nick Wiedenbrueck <https://github.com/cretzel>
 	Eduardo Gonçalves <https://github.com/Dudssource>
 	Thorsten Fleischmann <https://github.com/thorstenfleischmann>
+	Tilmann Hars <https://github.com/usysrc>

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1676,7 +1676,7 @@ local function get_introspection_endpoint(opts)
 end
 
 local function get_introspection_cache_prefix(opts)
-  return (opts.cache_segment and opts.cache_segment.gsub(',', '_') or 'DEFAULT') .. ','
+  return (opts.cache_segment and opts.cache_segment:gsub(',', '_') or 'DEFAULT') .. ','
     .. (get_introspection_endpoint(opts) or 'nil-endpoint') .. ','
     .. (opts.client_id or 'no-client_id') .. ','
     .. (opts.client_secret and 'secret' or 'no-client_secret') .. ':'
@@ -1786,7 +1786,7 @@ local function get_jwt_verification_cache_prefix(opts)
   for _, alg in ipairs(expected_algs) do
     signing_alg_values_expected = signing_alg_values_expected .. ',' .. alg
   end
-  return (opts.cache_segment and opts.cache_segment.gsub(',', '_') or 'DEFAULT') .. ','
+  return (opts.cache_segment and opts.cache_segment:gsub(',', '_') or 'DEFAULT') .. ','
     .. (opts.public_key or 'no-pubkey') .. ','
     .. (opts.symmetric_key or 'no-symkey') .. ','
     .. signing_alg_values_expected .. ':'


### PR DESCRIPTION
Calling bearer_jwt_verify fails because gsub is used incorrectly. This PR fixes the calls to gsub.

The error:
```
2022/04/22 07:18:01 [error] 9#9: *6 lua entry thread aborted: runtime error: /usr/local/openresty/lualib/resty/openidc.lua:1789: bad argument #3 to 'gsub' (string/function/table expected)
stack traceback:
coroutine 0:
	[C]: in function 'gsub'
	/usr/local/openresty/lualib/resty/openidc.lua:1789: in function 'get_jwt_verification_cache_prefix'
	/usr/local/openresty/lualib/resty/openidc.lua:1799: in function 'get_cached_jwt_verification'
	/usr/local/openresty/lualib/resty/openidc.lua:1817: in function 'jwt_verify'
	/usr/local/openresty/lualib/resty/openidc.lua:1860: in function 'bearer_jwt_verify'
	access_by_lua(nginx.conf:76):23: in main chunk, client: 172.17.0.1, server: , request: "GET / HTTP/1.1", host: "localhost:8080"
```

A minimal nginx.conf used to test this:
```
events {
  worker_connections 128;
}

http {

  lua_package_path '~/lua/?.lua;;';

  resolver 8.8.8.8;

  lua_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
  lua_ssl_verify_depth 5;

  # cache for discovery metadata documents
  lua_shared_dict discovery 1m;
  # cache for JWKs
  lua_shared_dict jwks 1m;
  # cache for jwt_verify
  lua_shared_dict jwt_verification 1m;

  # NB: if you have "lua_code_cache off;", use:
  # set $session_secret xxxxxxxxxxxxxxxxxxx;
  # see: https://github.com/bungle/lua-resty-session#notes-about-turning-lua-code-cache-off

  server {
    listen 8080;

    location / {

      access_by_lua_block {
          local opts = {
            discovery = "https://accounts.google.com/.well-known/openid-configuration",
            cache_segment = "openidc_app",
          }

          -- call bearer_jwt_verify for OAuth 2.0 JWT validation
          local res, err = require("resty.openidc").bearer_jwt_verify(opts)

           if err or not res then
            ngx.status = 403
            ngx.say(err and err or "no access_token provided")
            ngx.exit(ngx.HTTP_FORBIDDEN)
          end

          ngx.req.set_header("X-USER", res.id_token.sub)
      }

      proxy_pass http://localhost:80;
    }
  }
}
```