### PR TITLE
CI Tests: serpent version 0.28

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -10,7 +10,7 @@ RUN ["apt-get", "update"]
 RUN ["apt-get", "install", "-y", "git"]
 RUN ["luarocks", "install", "busted"]
 RUN ["luarocks", "install", "LuaSocket"]
-RUN ["luarocks", "install", "serpent"]
+RUN ["luarocks", "install", "serpent", "0.28"]
 RUN ["luarocks", "install", "dkjson"]
 RUN ["luarocks", "install", "luacov"]
 


### PR DESCRIPTION
This PR fixes the version of serpent to a working one (0.28). The latest version in luarocks seems to be broken currently.