### PR TITLE
Correct passing of 'symmetric_key' and thus fix HS??? verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,9 @@ http {
 
           local opts = {
 
-            -- 1. example of a shared secret for HS??? signature verification
+            -- 1. example of a shared secret for HS??? signature verification.
+            -- The key is passed as-is to HMAC and thus may contain binary data
+            -- and cannot be base64 or otherwise encoded.
             --symmetric_key = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             -- in versions up to 1.6.1 this option's key would have been secret
             -- rather than symmetric_key

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1045,7 +1045,7 @@ end
 --
 local function openidc_load_and_validate_jwt_id_token(opts, jwt_id_token, session)
 
-  local jwt_obj, err = openidc_load_jwt_and_verify_crypto(opts, jwt_id_token, opts.public_key, opts.client_secret,
+  local jwt_obj, err = openidc_load_jwt_and_verify_crypto(opts, jwt_id_token, opts.public_key, opts.symmetric_key,
     opts.discovery.id_token_signing_alg_values_supported)
   if err then
     local alg = (jwt_obj and jwt_obj.header and jwt_obj.header.alg) or ''


### PR DESCRIPTION
In function `openidc_load_and_validate_jwt_id_token()`, it was passing the
wrong `opts.client_secret` instead of `opts.symmetric_key` as the HMAC
key, and thus caused signature verification failures for HS??? tokens.

Fix the code to pass the correct `opts.symmetric_key`.

Meanwhile, update the REAME a bit to clarify that the `symmetric_key`
option is directly passed to HMAC code and thus cannot be encoded.