### PR TITLE
added support for registrations endpoint

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,3 +36,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Eduardo Gonçalves <https://github.com/Dudssource>
 	Thorsten Fleischmann <https://github.com/thorstenfleischmann>
 	Tilmann Hars <https://github.com/usysrc>
+	Bernhard Kuzel <https://github.com/burnes>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+09/12/2022
+- added support for registrations endpoint
+
 03/05/2022
 - improved error message when expecting a Bearer token header and the
   header doesn't contain a space character; see #421

--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ h2JHukolz9xf6qN61QMLSd83+kwoBr2drp6xg3eGDLIkQCQLrkY=
              --iat_slack = 600,
              --redirect_uri_scheme = "https",
              --logout_path = "/logout",
+             --registrations_endpoint = "https://my-oauth2-provider/realms/my-realm/protocol/openid-connect/registrations"
+             --   OAuth endpoint to be used when redirect to registration page is desired. Also requires 'registrations_path' to be set.
+             --registrations_path = "/registration",
+             --   Path on which a redirect to the registration page should be provided instead of the authorization page. Also requires 'registrations_endpoint' to be set.
              --redirect_after_logout_uri = "/",
              -- Where should the user be redirected after logout from the RP. This option overides any end_session_endpoint that the OP may have provided in the discovery response.
              --redirect_after_logout_with_id_token_hint = true,


### PR DESCRIPTION
Some OAuth providers provide an endpoint for a registration page instead of a login page. By configuring the `registrations_path` and `registrations_endpoint`, the `openidc_authorize` function will redirect to the configured endpoint including the same parameters as the authorization endpoint and prepare the session.

Can be used e.g. for providing direct Links to Keycloak's registration page.