### PR TITLE
Enable caching of negative introspection responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,19 @@ from the cache. In order to avoid cache confusion it is recommended to
 set `opts.cache_segment` to unique strings for each set of related
 locations.
 
+## Caching of negative Introspection responses
+
+By default `introspection` cache will not store negative responses.
+This means that bad actor can potentialy try to exhaust introspection 
+endpoint by flooding service with a lot of calls with inproper token.
+To prevent this situation `opts.introspection_enable_negative_cache`
+can be set to `true`. This will enable `introspection` cache to store
+negative responses for time defined in `exp` field.
+Caching negative introspection responses will offload traffic from
+introspection endpoint but also will expose NGINX for resource exhaustion
+attacks as storing negative introspection responses will use extra
+cache storage.
+
 ## Revoke tokens
 
 The `revoke_tokens(opts, session)` function revokes the current refresh and access token. In contrast to a full logout, the session cookie will not be destroyed and the endsession endpoint will not be called. The function returns `true` if both tokens were revoked successfully. This function might be helpful in scenarios where you want to destroy/remove a session from the server side.

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1819,6 +1819,13 @@ function openidc.introspect(opts)
     return json, err
   end
 
+  -- check if negative cache should be in use
+  local introspection_enable_negative_cache = opts.introspection_enable_negative_cache or false
+  if not json.active and not introspection_enable_negative_cache then
+    err = "invalid token"
+    return json, err
+  end
+
   -- cache the results
   local introspection_cache_ignore = opts.introspection_cache_ignore or false
   local expiry_claim = opts.introspection_expiry_claim or "exp"

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1780,6 +1780,11 @@ function openidc.introspect(opts)
 
   if v then
     json = cjson.decode(v)
+
+    if not json or not json.active then
+        err = "invalid cached token"
+    end
+
     return json, err
   end
 
@@ -1810,19 +1815,14 @@ function openidc.introspect(opts)
   end
   json, err = openidc.call_token_endpoint(opts, introspection_endpoint, body, opts.introspection_endpoint_auth_method, "introspection")
 
-
   if not json then
-    return json, err
-  end
-
-  if not json.active then
-    err = "invalid token"
     return json, err
   end
 
   -- cache the results
   local introspection_cache_ignore = opts.introspection_cache_ignore or false
   local expiry_claim = opts.introspection_expiry_claim or "exp"
+
 
   if not introspection_cache_ignore and json[expiry_claim] then
     local introspection_interval = opts.introspection_interval or 0
@@ -1837,6 +1837,10 @@ function openidc.introspect(opts)
     end
     log(DEBUG, "cache token ttl: " .. ttl)
     set_cached_introspection(opts, access_token, cjson.encode(json), ttl)
+  end
+
+  if not json.active then
+    err = "invalid token"
   end
 
   return json, err


### PR DESCRIPTION
Right now every single introspection response which has `active` field not set to `true` is just rejected. In situation where there are multiple calls using the same expired/revoked/wrong token response from introspection endpoint could be cached for time set in `exp` field.
This change will allow to do so. By simple configuration in introspection service it will be possible to enable or not (by setting proper value to `exp` field) caching of responses for inactive tokens.