### PR TITLE
Incorrect Handling of Bearer Token with trailing space in openidc_get_bearer_access_token

### DIFF
--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -222,6 +222,13 @@ local function get_first_header_and_strip_whitespace(headers, header_name)
   return header and header:gsub('%s', '')
 end
 
+local function trim(s)
+  if s then
+    return s:match("^%s*(.-)%s*$")
+  end
+  return s
+end
+
 local function get_forwarded_parameter(headers, param_name)
   local forwarded = get_first_header(headers, 'Forwarded')
   local params = {}
@@ -1701,7 +1708,7 @@ local function openidc_get_bearer_access_token(opts)
   -- get the access token from the Authorization header
   local headers = ngx.req.get_headers()
   local header_name = opts.auth_accept_token_as_header_name or "Authorization"
-  local header = get_first(headers[header_name])
+  local header = trim(get_first(headers[header_name]))
 
   if header == nil then
     err = "no Authorization header found"

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1724,7 +1724,7 @@ local function openidc_get_bearer_access_token(opts)
   end
 
   local access_token = header:sub(divider + 1)
-  if access_token == nil then
+  if access_token == "" then
     err = "no Bearer access token value found"
     log(ERROR, err)
     return nil, err


### PR DESCRIPTION
### Summary
This PR improves the `openidc_get_bearer_access_token` function by trimming whitespace from headers and ensuring proper validation of the extracted access token. (Fixes #537)

### Changes
- Added a `trim` function to remove leading and trailing whitespace from headers before processing.
- Changed the validation check from `nil` to `""` since `header:sub(divider + 1)` always return a string.
- If the token is missing, it will be an empty string (`""`) rather than `nil`.
- This ensures invalid tokens are correctly identified.

### Impact
These improvements enhance robustness and prevent potential issues with incorrectly formatted headers.

### Test Results

After these changes, the unit tests improved from 498 successes / 11 failures to 503 successes / 0 failures.

Before:

![image](https://github.com/user-attachments/assets/a25ef7f6-cd0d-45fa-8ca7-e39bbdbcb675)

After:

![image](https://github.com/user-attachments/assets/e6cc7703-ead9-45d8-ac57-2485fde259a9)

